### PR TITLE
Update PWA icon references to existing assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <meta name="theme-color" content="#0B0C10">
   <title>Social Risk Audit</title>
   <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" sizes="512x512" href="/icons-s/1.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="512x512" href="/icons-s/2.png">
   <link rel="stylesheet" href="./assets/css/styles.css">
 </head>
 <body>

--- a/manifest.json
+++ b/manifest.json
@@ -8,16 +8,16 @@
   "background_color": "#0B0C10",
   "icons": [
     {
-      "src": "/icons/app-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icons/app-512.png",
+      "src": "/icons-s/1.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable any"
+    },
+    {
+      "src": "/icons-s/2.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable any"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point the web app manifest to the existing 512x512 icons in /icons-s
- add favicon and Apple touch icon links in index.html to use the existing icons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87ad5eb9c83239dfe39b1d80ddcd1