### PR TITLE
Add ethics page and sharing metadata

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1017,3 +1017,56 @@ body.prefers-reduced-motion {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
+
+.view.page-ethics {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.page-ethics {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.page-ethics .glass {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  padding: 20px;
+}
+
+.page-ethics h1 {
+  font-size: clamp(1.4rem, 2.5vw, 2rem);
+  margin: 0 0 12px;
+}
+
+.page-ethics h3 {
+  margin-top: 16px;
+  font-size: 1.05rem;
+}
+
+.page-ethics p {
+  line-height: 1.6;
+  margin: 10px 0;
+}
+
+.page-ethics ul {
+  margin: 8px 0 8px 20px;
+}
+
+.page-ethics .back-link {
+  display: inline-block;
+  margin-top: 16px;
+}
+
+.link {
+  color: var(--accent, #0FF0FC);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,4 @@
-import { createRouter } from './router.js';
+import { createRouter, handleEthicsRoute } from './router.js';
 import { createChip, showToast, createPopover, showTooltip } from './components.js';
 import { initGuidesModule } from './guides.js';
 import { showDisclaimerOnLoad } from './disclaimer.js';
@@ -9,6 +9,7 @@ const views = {
   guideDetail: document.getElementById('view-guide-detail'),
   tools: document.getElementById('view-tools'),
   about: document.getElementById('view-about'),
+  ethics: document.getElementById('view-ethics'),
   settings: document.getElementById('view-settings'),
 };
 
@@ -38,6 +39,12 @@ const state = {
 
 let router = null;
 let guidesModule = null;
+
+const BASE_TITLE = 'Social Risk Audit';
+
+function updateDocumentTitle(segment) {
+  document.title = segment ? `${segment} — ${BASE_TITLE}` : BASE_TITLE;
+}
 
 function applyReducedMotionPreference() {
   if (!document.body) return;
@@ -277,39 +284,52 @@ function setupRouter() {
   router.addRoute('/', ({ path }) => {
     setActiveView('home');
     setActiveDock(path);
+    updateDocumentTitle();
     renderHome();
   });
 
   router.addRoute('/guides', ({ query }) => {
     setActiveView('guides');
     setActiveDock('/guides');
+    updateDocumentTitle('Guides');
     guidesModule.showIndex({ query });
   });
 
   router.addRoute('/guides/:slug', ({ params, query }) => {
     setActiveView('guideDetail');
     setActiveDock('/guides');
+    updateDocumentTitle('Guides');
     guidesModule.showDetail({ slug: params.slug, query });
   });
 
   router.addRoute('/tools', ({ path }) => {
     setActiveView('tools');
     setActiveDock(path);
+    updateDocumentTitle('Tools');
   });
 
   router.addRoute('/about', ({ path }) => {
     setActiveView('about');
     setActiveDock(path);
+    updateDocumentTitle('About');
+  });
+
+  router.addRoute('/ethics', async ({ path }) => {
+    setActiveView('ethics');
+    setActiveDock('/about');
+    await handleEthicsRoute(views.ethics);
   });
 
   router.addRoute('/settings', ({ path }) => {
     setActiveView('settings');
     setActiveDock(path);
+    updateDocumentTitle('Settings');
   });
 
   router.setNotFound(() => {
     setActiveView('home');
     setActiveDock('/');
+    updateDocumentTitle();
   });
 
   router.start();

--- a/assets/js/pages/ethics.js
+++ b/assets/js/pages/ethics.js
@@ -1,0 +1,123 @@
+const SOURCE_URL = '/data/ethics.md';
+let cachedMarkdown = null;
+
+function normalizeText(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
+function createList(lines) {
+  const list = document.createElement('ul');
+  lines.forEach((line) => {
+    const value = line.replace(/^[-•]\s*/, '').replace(/^✋\s*/, '').trim();
+    if (!value) return;
+    const item = document.createElement('li');
+    item.textContent = value;
+    list.appendChild(item);
+  });
+  return list;
+}
+
+function isHeading(line) {
+  if (!line) return false;
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (/[:：]$/.test(trimmed)) {
+    return true;
+  }
+  const hasLetters = /[A-Za-z]/.test(trimmed);
+  return hasLetters && trimmed === trimmed.toUpperCase();
+}
+
+function createParagraph(text) {
+  const paragraph = document.createElement('p');
+  paragraph.textContent = text.replace(/\s+/g, ' ').trim();
+  return paragraph;
+}
+
+function transformMarkdown(markdown) {
+  const fragment = document.createDocumentFragment();
+  if (!markdown) return fragment;
+  const blocks = normalizeText(markdown).split(/\n\s*\n/);
+  blocks.forEach((block) => {
+    const trimmedBlock = block.trim();
+    if (!trimmedBlock) return;
+    const lines = trimmedBlock.split('\n').map((line) => line.trim());
+    const listLines = lines.filter((line) => /^[-•✋]/.test(line));
+    if (listLines.length === lines.length && listLines.length > 0) {
+      fragment.appendChild(createList(listLines));
+      return;
+    }
+    const [firstLine, ...rest] = lines;
+    if (isHeading(firstLine)) {
+      const heading = document.createElement('h3');
+      heading.textContent = firstLine.replace(/[:：]$/, '').trim();
+      fragment.appendChild(heading);
+      if (rest.length) {
+        fragment.appendChild(createParagraph(rest.join(' ')));
+      }
+      return;
+    }
+    fragment.appendChild(createParagraph(lines.join(' ')));
+  });
+  return fragment;
+}
+
+async function loadMarkdown() {
+  if (cachedMarkdown) {
+    return cachedMarkdown;
+  }
+  const response = await fetch(SOURCE_URL);
+  if (!response.ok) {
+    throw new Error('Failed to load ethics document');
+  }
+  cachedMarkdown = await response.text();
+  return cachedMarkdown;
+}
+
+export async function renderEthics(root) {
+  if (!root) return;
+
+  root.innerHTML = '';
+  root.classList.add('page-ethics');
+
+  const main = document.createElement('main');
+  main.setAttribute('role', 'main');
+  const card = document.createElement('div');
+  card.className = 'glass';
+
+  const heading = document.createElement('h1');
+  heading.id = 'ethics-title';
+  heading.tabIndex = -1;
+  heading.dataset.i18n = 'pages.ethics.title';
+  heading.textContent = 'Ethics & Morality';
+
+  const intro = document.createElement('p');
+  intro.dataset.i18n = 'pages.ethics.intro';
+  intro.textContent = 'Our work is privacy-first, consent-based, and never used to harm. This page states the standards.';
+
+  const content = document.createElement('div');
+  content.className = 'ethics-content';
+
+  const backLink = document.createElement('a');
+  backLink.href = '#/about';
+  backLink.classList.add('link', 'back-link');
+  backLink.textContent = 'Back to About';
+
+  card.append(heading, intro, content, backLink);
+  main.appendChild(card);
+  root.appendChild(main);
+
+  try {
+    const markdown = await loadMarkdown();
+    content.innerHTML = '';
+    content.appendChild(transformMarkdown(markdown));
+  } catch (error) {
+    console.error(error);
+    content.innerHTML = '';
+    content.appendChild(createParagraph('We could not load the ethics statement. Please try again later.'));
+  }
+
+  requestAnimationFrame(() => {
+    heading.focus({ preventScroll: true });
+  });
+}

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,3 +1,5 @@
+import { renderEthics } from './pages/ethics.js';
+
 export function createRouter() {
   const routes = [];
   let notFoundHandler = null;
@@ -128,4 +130,9 @@ export function createRouter() {
     navigate,
     getCurrent,
   };
+}
+
+export async function handleEthicsRoute(root) {
+  document.title = 'Ethics — Social Risk Audit';
+  await renderEthics(root);
 }

--- a/data/ethics.md
+++ b/data/ethics.md
@@ -1,0 +1,24 @@
+MISSION AND DUTY:
+We operate solely to protect the privacy, agency, and psychological safety of the people who trust us. Every assessment is framed around minimizing risk, preventing exploitation, and strengthening informed consent.
+
+CORE PRINCIPLES
+- Privacy-first intelligence gathering for defensive readiness.
+- Consent before any data is accessed, processed, or shared.
+✋ We never weaponize insights for harassment, doxing, intimidation, or political targeting.
+
+PRACTICAL BOUNDARIES:
+Our investigations focus on exposures already visible to the account holder or their authorized team. We do not penetrate accounts, defeat platform safeguards, or encourage adversarial breaches. If a requested action crosses that line, we decline the task.
+
+HUMAN IMPACT:
+We recognize that digital harm extends beyond metrics. We weigh trauma, reputational damage, and downstream abuse when advising on next steps. Psychological welfare, especially for marginalized communities, guides the pace and scope of our work.
+
+SAFEGUARDS IN PRACTICE:
+- Limit retention to the shortest window needed to deliver remediation guidance.
+- ✋ Pause work immediately if a client signals discomfort or revokes consent.
+- Document sources, transformations, and recommendations for accountability.
+
+ESCALATION:
+When we encounter imminent harm, we prioritize de-escalation and protection. We coordinate with trusted partners only when the impacted person provides explicit approval, or when legal obligations require notification.
+
+ACCOUNTABILITY:
+We invite peer review, red teaming, and transparent critique of our methodologies. Findings that expose bias or unintended harm trigger corrective action plans and public documentation of the fix.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,5 +29,14 @@
     "agree": "I Agree",
     "disagree": "I Do Not Agree",
     "leave": "Leave site"
+  },
+  "pages": {
+    "ethics": {
+      "title": "Ethics & Morality",
+      "intro": "Our work is privacy-first, consent-based, and never used to harm. This page states the standards."
+    }
+  },
+  "links": {
+    "ethics": "Ethics"
   }
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -29,5 +29,14 @@
     "agree": "אני מסכים/ה",
     "disagree": "אינני מסכים/ה",
     "leave": "עזוב את האתר"
+  },
+  "pages": {
+    "ethics": {
+      "title": "Ethics & Morality",
+      "intro": "Our work is privacy-first, consent-based, and never used to harm. This page states the standards."
+    }
+  },
+  "links": {
+    "ethics": "Ethics"
   }
 }

--- a/index.html
+++ b/index.html
@@ -5,15 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#0B0C10">
   <title>Social Risk Audit</title>
-  <meta name="description" content="Expose hidden threats and get actionable fixes before social crises erupt.">
-  <meta property="og:title" content="Social Risk Audit">
-  <meta property="og:description" content="Expose hidden threats and get actionable fixes before social crises erupt.">
-  <meta property="og:image" content="/icons-s/1.png">
-  <meta property="og:url" content="https://osintsecrets.github.io/PRIVACY/">
+  <meta name="title" content="Social Risk Audit">
+  <meta name="description" content="Your step-by-step Facebook privacy toolkit. Learn it. Fix it. Own it.">
+  <!-- Open Graph -->
   <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/PRIVACY/">
+  <meta property="og:title" content="Social Risk Audit">
+  <meta property="og:description" content="Your step-by-step Facebook privacy toolkit. Learn it. Fix it. Own it.">
+  <meta property="og:image" content="/icons-s/1.png">
+  <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Social Risk Audit">
-  <meta name="twitter:description" content="Expose hidden threats and get actionable fixes before social crises erupt.">
+  <meta name="twitter:description" content="Your step-by-step Facebook privacy toolkit. Learn it. Fix it. Own it.">
   <meta name="twitter:image" content="/icons-s/1.png">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/png" sizes="512x512" href="/icons-s/1.png">
@@ -78,9 +81,12 @@
           <ul class="placeholder-list">
             <li>Our mission: reduce social risk exposure.</li>
             <li>Built for journalists, advocates, and teams.</li>
+            <li><a href="#/ethics" class="link" data-i18n="links.ethics">Ethics</a></li>
           </ul>
         </div>
       </section>
+
+      <section id="view-ethics" class="view page-ethics" data-route="/ethics" aria-labelledby="ethics-title"></section>
 
       <section id="view-settings" class="view" data-route="/settings" aria-labelledby="settings-title">
         <div class="section-heading">


### PR DESCRIPTION
## Summary
- add full Open Graph and Twitter metadata to the landing page and surface an Ethics link
- register an Ethics route that renders markdown content with glass styling and updates the document title
- source the ethics copy from a markdown file and expose supporting styles and translations

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d883b33fec83238f68d62010b2c72f