### PR TITLE
Fix ethics markdown fetch path for subdirectory hosting

### DIFF
--- a/assets/js/pages/ethics.js
+++ b/assets/js/pages/ethics.js
@@ -1,4 +1,4 @@
-const SOURCE_URL = '/data/ethics.md';
+const SOURCE_URL = new URL('./data/ethics.md', window.location.href).toString();
 let cachedMarkdown = null;
 
 function normalizeText(text) {


### PR DESCRIPTION
## Summary
- load the ethics markdown using a URL that resolves relative to the current page so it works from subdirectories

## Testing
- npx serve -l 4173 --no-clipboard .
- Playwright check http://127.0.0.1:4173/#/ethics


------
https://chatgpt.com/codex/tasks/task_e_68d88a5bfcd88323ba2a18d6ea6d2dba