### PR TITLE
Remove placeholder effective date from disclaimer

### DIFF
--- a/data/disclaimer.txt
+++ b/data/disclaimer.txt
@@ -1,5 +1,3 @@
-Effective Date: [Insert Date]
-
 This Comprehensive Legal, Ethical, and Moral Disclaimer ("Disclaimer") governs your use of the Social Risk Audit application (the "Service"). By accessing or using the Service you acknowledge that you have read, understood, and agree to be bound by this Disclaimer. If you do not agree, you must immediately cease using the Service.
 
 The Service is provided for educational, research, and risk-awareness purposes only. Nothing contained within the Service should be construed as legal advice, security guarantees, crisis management direction, or a substitute for professional counsel. You alone bear responsibility for obtaining qualified legal, regulatory, psychological, security, or other professional assistance as needed.


### PR DESCRIPTION
## Summary
- remove the placeholder "Effective Date" line from the disclaimer text file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89a4ef8748323bf00af7f2f4d8b75