### PR TITLE
Fix modal overflow to enable scrolling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -530,6 +530,7 @@ select:disabled {
   padding: 28px;
   max-height: 90vh;
   overflow: hidden;
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 .modal-header h2 {
@@ -537,6 +538,7 @@ select:disabled {
 }
 
 .modal-body {
+  min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- configure the modal layout to allocate flexible space for its content
- allow the modal body region to scroll within the constrained viewport height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8b4b2cc388323a591aa411eb7df9d