### PR TITLE
Convert hamburger menu into dropdown overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -5,15 +5,19 @@ body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 var(--font-sa
 a{color:var(--accent);}a:hover{text-decoration:underline;}
 a:focus-visible{outline:2px solid var(--accent);outline-offset:3px;}
 .wrapper{max-width:72ch;margin:0 auto;padding:calc(var(--space)*2) var(--space);}
-header{position:sticky;top:0;z-index:10;background:#0c1117;border-bottom:1px solid var(--border);} 
+header{position:sticky;top:0;z-index:10;background:#0c1117;border-bottom:1px solid var(--border);}
 .header-row{display:flex;align-items:center;justify-content:space-between;gap:var(--space);}
 .brand{color:var(--text);text-decoration:none;font-weight:700;}
 .menu-toggle{background:#0e1820;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;min-width:44px;min-height:44px;}
 .menu-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
-.menu{display:flex;flex-direction:column;gap:6px;padding:0 var(--space) var(--space);}
-.menu a{display:block;padding:10px 12px;border-radius:10px;color:var(--muted);text-decoration:none;}
+.menu-container{position:relative;display:flex;align-items:center;}
+.menu{display:flex;flex-direction:column;gap:6px;padding:12px;background:#0e151b;border:1px solid var(--border);border-radius:12px;position:absolute;top:calc(100% + 10px);right:0;width:min(240px,calc(100vw - var(--space)*2));box-shadow:0 18px 40px rgba(0,0,0,0.45);z-index:20;}
+.menu::before{content:"";position:absolute;top:-10px;right:18px;width:16px;height:16px;transform:rotate(45deg);background:#0e151b;border-left:1px solid var(--border);border-top:1px solid var(--border);z-index:19;}
+.menu a{display:block;padding:10px 12px;border-radius:10px;color:var(--muted);text-decoration:none;position:relative;z-index:1;}
 .menu a[aria-current="page"]{background:#0f1b20;color:var(--text);}
 .menu a:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.menu[hidden]{display:none;}
+.menu[hidden]::before{display:none;}
 .skip{position:absolute;left:-9999px;}
 .skip:focus{left:var(--space);top:var(--space);background:#001519;padding:8px 10px;border-radius:8px;}
 main{display:block;}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,10 +2,20 @@
   const btn = document.querySelector('.menu-toggle');
   const menu = document.getElementById('site-menu');
   if (!btn || !menu) return;
+  const container = btn.closest('.menu-container') || btn.parentElement;
+  const outsideClick = (event) => {
+    if (!container || container.contains(event.target)) return;
+    toggle(false);
+  };
+  const manageOutside = (listen) => {
+    const method = listen ? 'addEventListener' : 'removeEventListener';
+    document[method]('pointerdown', outsideClick);
+  };
   const toggle = (open) => {
     const isOpen = open ?? menu.hasAttribute('hidden');
     if (isOpen) menu.removeAttribute('hidden'); else menu.setAttribute('hidden', '');
     btn.setAttribute('aria-expanded', String(isOpen));
+    manageOutside(isOpen);
     if (isOpen) menu.querySelector('a')?.focus();
   };
   btn.addEventListener('click', () => toggle());

--- a/ethics.html
+++ b/ethics.html
@@ -12,14 +12,16 @@
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
       <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
-      <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-label="Open menu">☰</button>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+        </nav>
+      </div>
     </div>
-    <nav id="site-menu" class="menu" hidden aria-label="Primary">
-      <a href="/PRIVACY/" data-nav="home">Home</a>
-      <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-      <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-      <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-    </nav>
   </header>
   <main id="main">
     <div class="wrapper">

--- a/index.html
+++ b/index.html
@@ -12,14 +12,16 @@
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
       <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
-      <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-label="Open menu">☰</button>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+        </nav>
+      </div>
     </div>
-    <nav id="site-menu" class="menu" hidden aria-label="Primary">
-      <a href="/PRIVACY/" data-nav="home">Home</a>
-      <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-      <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-      <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-    </nav>
   </header>
   <main id="main">
     <section class="wrapper">

--- a/platform.html
+++ b/platform.html
@@ -12,14 +12,16 @@
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
       <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
-      <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-label="Open menu">☰</button>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+        </nav>
+      </div>
     </div>
-    <nav id="site-menu" class="menu" hidden aria-label="Primary">
-      <a href="/PRIVACY/" data-nav="home">Home</a>
-      <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-      <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-      <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-    </nav>
   </header>
   <main id="main">
     <div class="wrapper">

--- a/why.html
+++ b/why.html
@@ -12,14 +12,16 @@
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
       <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
-      <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-label="Open menu">☰</button>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+        </nav>
+      </div>
     </div>
-    <nav id="site-menu" class="menu" hidden aria-label="Primary">
-      <a href="/PRIVACY/" data-nav="home">Home</a>
-      <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-      <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-      <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-    </nav>
   </header>
   <main id="main">
     <div class="wrapper">


### PR DESCRIPTION
## Summary
- wrap the navigation markup in a dedicated container and add aria attributes for the toggle button
- restyle the primary navigation so the hamburger opens a floating dropdown panel
- close the menu when clicking outside while preserving focus handling for keyboard users

## Testing
- Manual confirmation via Playwright screenshot (artifacts/hamburger-menu.png)


------
https://chatgpt.com/codex/tasks/task_e_68da5764a21483239d44d1ea1dc12dcb