### PR TITLE
Add platform hub and individual platform pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,3 +39,12 @@ summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-
 footer{border-top:1px solid var(--border);color:#85b6bd;background:#0c1117;}
 footer .wrapper{padding-top:var(--space);padding-bottom:var(--space);font-size:0.9rem;}
 :root[data-rm='on'] *,[data-rm='on'] *{transition:none!important;animation:none!important;}
+.lead{ color:var(--muted); margin-bottom: var(--space); }
+.grid{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: var(--space); }
+@media (min-width: 720px){ .grid{ grid-template-columns: repeat(3, minmax(0,1fr)); } }
+.tile{ display:flex; align-items:center; justify-content:center; min-height: 100px; border:1px solid var(--border); border-radius: var(--radius); background: var(--card, #0f141b); color: var(--text); text-decoration:none; font-weight:600; }
+.tile:hover{ background:#0f1b20; }
+.tile:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+.crumbs{ margin-bottom: var(--space); }
+.crumb.back{ display:inline-block; padding:8px 10px; border-radius:10px; border:1px solid var(--border); background:#0e1820; color:var(--text); text-decoration:none; }
+.crumb.back:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,7 +23,18 @@
   menu.addEventListener('keydown', (e)=>{ if(e.key==='Escape'){ toggle(false); btn.focus(); } });
   menu.querySelectorAll('a').forEach(a=> a.addEventListener('click', ()=> toggle(false)));
   // Mark current nav item
-  const map = { '/PRIVACY/':'home', '/PRIVACY/platform.html':'platform', '/PRIVACY/ethics.html':'ethics', '/PRIVACY/why.html':'why' };
+  const map = {
+    '/PRIVACY/': 'home',
+    '/PRIVACY/platform.html': 'platform',
+    '/PRIVACY/platforms/facebook.html': 'platform',
+    '/PRIVACY/platforms/instagram.html': 'platform',
+    '/PRIVACY/platforms/x.html': 'platform',
+    '/PRIVACY/platforms/tiktok.html': 'platform',
+    '/PRIVACY/platforms/whatsapp.html': 'platform',
+    '/PRIVACY/platforms/telegram.html': 'platform',
+    '/PRIVACY/ethics.html': 'ethics',
+    '/PRIVACY/why.html': 'why'
+  };
   const key = Object.keys(map).find(p => location.pathname.endsWith(p.replace('/PRIVACY','')) || location.pathname===p);
   const sel = key ? `[data-nav="${map[key]}"]` : null;
   if (sel) document.querySelector(sel)?.setAttribute('aria-current','page');

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — Facebook</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>Facebook</h1>
+    <p class="lead">Practical privacy actions you can take today on Facebook.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — Instagram</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>Instagram</h1>
+    <p class="lead">Practical privacy actions you can take today on Instagram.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — Telegram</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>Telegram</h1>
+    <p class="lead">Practical privacy actions you can take today on Telegram.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — TikTok</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>TikTok</h1>
+    <p class="lead">Practical privacy actions you can take today on TikTok.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — WhatsApp</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>WhatsApp</h1>
+    <p class="lead">Practical privacy actions you can take today on WhatsApp.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
-  <title>Social Risk Audit — Platforms</title>
+  <title>Social Risk Audit — X</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
 </head>
 <body>
@@ -23,24 +23,33 @@
       </div>
     </div>
   </header>
-  <main id="main" class="wrapper">
-    <h1>Choose a Platform</h1>
-    <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+  <main id="main" class="wrapper">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+    </nav>
+
+    <h1>X</h1>
+    <p class="lead">Practical privacy actions you can take today on X.</p>
+
+    <section class="card">
+      <h2>Quick Start</h2>
+      <details>
+        <summary>Example task — placeholder</summary>
+        <ol>
+          <li>Open the app</li>
+          <li>Go to Settings</li>
+          <li>Find Privacy &amp; Security</li>
+          <li>Adjust key controls</li>
+        </ol>
+      </details>
     </section>
   </main>
+
   <footer>
-    <div class="wrapper">
-      <p>Last updated: September 2023. Built for fast, private browsing.</p>
-    </div>
+    <div class="wrapper">Utility-first build — no trackers.</div>
   </footer>
+
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the platform checklist with a grid of six platform links
- add placeholder detail pages for Facebook, Instagram, X, TikTok, WhatsApp, and Telegram with breadcrumbs back to the hub
- extend navigation highlighting and add utility styles for the new grid and breadcrumbs

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68de6281f27c832399fe2a4883957fb6