### PR TITLE
Add Facebook privacy guides and supporting styles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -48,3 +48,8 @@ footer .wrapper{padding-top:var(--space);padding-bottom:var(--space);font-size:0
 .crumbs{ margin-bottom: var(--space); }
 .crumb.back{ display:inline-block; padding:8px 10px; border-radius:10px; border:1px solid var(--border); background:#0e1820; color:var(--text); text-decoration:none; }
 .crumb.back:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+.card h2 + .lead { margin-top: .5rem; }
+.card details { margin-top: .75rem; }
+.card details + details { margin-top: .5rem; }
+.card ol { padding-left: 1.25rem; }
+nav.card ol { padding-left: 1.25rem; }

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -32,18 +32,592 @@
     <h1>Facebook</h1>
     <p class="lead">Practical privacy actions you can take today on Facebook.</p>
 
+    <!-- FB_GUIDES_START -->
     <section class="card">
-      <h2>Quick Start</h2>
-      <details>
-        <summary>Example task — placeholder</summary>
+      <h2>Navigation Primer</h2>
+      <h3>Mobile (Facebook app)</h3>
+      <ul>
+        <li><strong>App icon:</strong> Blue square with white &quot;f&quot;. Open it and sign in.</li>
+        <li><strong>Menu (=):</strong> Three horizontal lines. Usually <strong>bottom-right on iPhone</strong> and <strong>top-right on many Android</strong>. If you don&#x27;t see =, tap your <strong>profile picture (small circle) at top-right</strong>, then tap <strong>Settings &amp; privacy</strong>.</li>
+        <li><strong>Settings &amp; privacy then Settings:</strong> Scroll near the bottom of the Menu screen.</li>
+        <li><strong>Accounts Center:</strong> Lives inside <strong>Settings</strong>. It manages <strong>Password &amp; security</strong> and some privacy controls.</li>
+      </ul>
+      <h3>Desktop (computer browser)</h3>
+      <ul>
+        <li>Go to <strong>facebook.com</strong> and sign in.</li>
+        <li><strong>Profile picture (top-right):</strong> Small circular photo; click it to open the main menu.</li>
+        <li><strong>Settings &amp; privacy then Settings:</strong> Found in that dropdown. On some layouts you&#x27;ll see <strong>Settings</strong> first, then <strong>Accounts Center</strong> in the left sidebar.</li>
+        <li><strong>Left sidebar:</strong> Navigation list on the left of the Settings page (e.g., <strong>Privacy</strong>, <strong>Your Facebook information</strong>, etc.).</li>
+      </ul>
+      <p class="lead">If your layout looks different, use the <strong>Settings search bar</strong> (top of the Settings page) and type the feature name (e.g., &quot;Two-factor&quot;, &quot;Public posts&quot;).</p>
+    </section>
+    <nav class="card" aria-label="Guides">
+      <h2>Guides</h2>
+      <ol>
+        <li><a href="#guide-change-your-password">Change Your Password</a></li>
+        <li><a href="#guide-enable-two-factor-authentication-2fa">Enable Two-Factor Authentication (2FA)</a></li>
+        <li><a href="#guide-add-a-passkey-if-available">Add a Passkey (if available)</a></li>
+        <li><a href="#guide-review-log-out-unknown-sessions">Review &amp; Log Out Unknown Sessions</a></li>
+        <li><a href="#guide-turn-on-login-alerts">Turn On Login Alerts</a></li>
+        <li><a href="#guide-update-recovery-contact-info">Update Recovery Contact Info</a></li>
+        <li><a href="#guide-add-a-hardware-security-key">Add a Hardware Security Key</a></li>
+        <li><a href="#guide-remove-remembered-devices-2fa">Remove Remembered Devices (2FA)</a></li>
+        <li><a href="#guide-clear-saved-logins-on-shared-devices">Clear Saved Logins on Shared Devices</a></li>
+        <li><a href="#guide-recognize-avoid-phishing">Recognize &amp; Avoid Phishing</a></li>
+        <li><a href="#guide-set-default-audience-for-future-posts">Set Default Audience for Future Posts</a></li>
+        <li><a href="#guide-limit-past-post-audience-bulk">Limit Past Post Audience (Bulk)</a></li>
+        <li><a href="#guide-hide-your-friends-list">Hide Your Friends List</a></li>
+        <li><a href="#guide-restrict-friend-requests">Restrict Friend Requests</a></li>
+        <li><a href="#guide-restrict-lookup-by-email">Restrict Lookup by Email</a></li>
+        <li><a href="#guide-restrict-lookup-by-phone-number">Restrict Lookup by Phone Number</a></li>
+        <li><a href="#guide-disable-search-engine-linking-to-your-profile">Disable Search-Engine Linking to Your Profile</a></li>
+        <li><a href="#guide-hide-active-status-facebook-messenger">Hide Active Status (Facebook &amp; Messenger)</a></li>
+        <li><a href="#guide-turn-on-timeline-review-approve-posts-you-re-tagged-in">Turn On Timeline Review (Approve Posts You&#x27;re Tagged In)</a></li>
+        <li><a href="#guide-turn-on-tag-review-approve-tags-people-add">Turn On Tag Review (Approve Tags People Add)</a></li>
+        <li><a href="#guide-restrict-who-can-post-on-your-profile">Restrict Who Can Post on Your Profile</a></li>
+        <li><a href="#guide-limit-comments-on-your-public-posts">Limit Comments on Your Public Posts</a></li>
+        <li><a href="#guide-delete-a-post">Delete a Post</a></li>
+        <li><a href="#guide-delete-a-photo">Delete a Photo</a></li>
+        <li><a href="#guide-remove-your-tag-from-a-photo-or-post">Remove Your Tag from a Photo or Post</a></li>
+        <li><a href="#guide-delete-a-comment-you-made">Delete a Comment You Made</a></li>
+        <li><a href="#guide-remove-a-reaction-or-unlike-a-post">Remove a Reaction or Unlike a Post</a></li>
+        <li><a href="#guide-remove-check-ins-and-location-tags">Remove Check-Ins and Location Tags</a></li>
+        <li><a href="#guide-archive-or-delete-old-stories">Archive or Delete Old Stories</a></li>
+        <li><a href="#guide-review-and-lock-down-albums">Review and Lock Down Albums</a></li>
+      </ol>
+    </nav>
+    <section class="card" id="guide-change-your-password">
+      <h2>Change Your Password</h2>
+      <details open>
+        <summary>On Desktop</summary>
         <ol>
-          <li>Open the app</li>
-          <li>Go to Settings</li>
-          <li>Find Privacy &amp; Security</li>
-          <li>Adjust key controls</li>
+          <li>Open a browser and go to <strong>facebook.com</strong> then sign in.</li>
+          <li>Click your <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li>In the left sidebar, click <strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Change password</strong>.</li>
+          <li>Enter your current password, then your new password twice then click <strong>Save</strong>.</li>
         </ol>
       </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open the <strong>Facebook app</strong> then sign in.</li>
+          <li>Tap the <strong>Menu (=)</strong> (iPhone: bottom-right; Android: top-right). If not visible, tap your <strong>profile picture (top-right)</strong>.</li>
+          <li>Scroll down then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong>.</li>
+          <li>Tap <strong>Password and security</strong> then <strong>Change password</strong> then follow the prompts then <strong>Save</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Use at least 12 characters with letters, numbers, and symbols. Don&#x27;t reuse passwords.</p>
     </section>
+    <section class="card" id="guide-enable-two-factor-authentication-2fa">
+      <h2>Enable Two-Factor Authentication (2FA)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then sign in then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li><strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Two-factor authentication</strong>.</li>
+          <li>Choose <strong>Authenticator app</strong> (recommended) or <strong>Security key</strong> then follow on-screen steps then <strong>Turn on</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open app then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong>.</li>
+          <li><strong>Password and security</strong> then <strong>Two-factor authentication</strong> then pick <strong>Authenticator app</strong> or <strong>Security key</strong> then finish setup.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Write down/secure your <strong>backup codes</strong>. Avoid SMS 2FA if possible.</p>
+    </section>
+    <section class="card" id="guide-add-a-passkey-if-available">
+      <h2>Add a Passkey (if available)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li><strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Passkeys</strong> then follow device prompts (Face/Touch ID, PIN) then <strong>Enable</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong>.</li>
+          <li><strong>Password and security</strong> then <strong>Passkeys</strong> then follow prompts then <strong>Enable</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Passkeys are phishing-resistant and tie login to your device.</p>
+    </section>
+    <section class="card" id="guide-review-log-out-unknown-sessions">
+      <h2>Review &amp; Log Out Unknown Sessions</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li><strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Where you&#x27;re logged in</strong>.</li>
+          <li>Review the list of devices and locations then click <strong>...</strong> next to anything unfamiliar then <strong>Log out</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong>.</li>
+          <li><strong>Password and security</strong> then <strong>Where you&#x27;re logged in</strong> then tap any unknown session then <strong>Log out</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Do this monthly, especially after travel or using shared devices.</p>
+    </section>
+    <section class="card" id="guide-turn-on-login-alerts">
+      <h2>Turn On Login Alerts</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li><strong>Accounts Center</strong> then <strong>Password and security</strong> then find <strong>Alerts/Notifications</strong> about unrecognized logins then <strong>Turn on</strong> for email and notifications.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong>.</li>
+          <li><strong>Password and security</strong> then enable alerts for unrecognized logins.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Choose both <strong>Email</strong> and <strong>Push notification</strong> for redundancy.</p>
+    </section>
+    <section class="card" id="guide-update-recovery-contact-info">
+      <h2>Update Recovery Contact Info</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li><strong>Accounts Center</strong> then <strong>Personal details</strong> then <strong>Contact info</strong> then <strong>Add new email/phone</strong> then verify then ensure visibility of these fields is <strong>Only me</strong> (adjust under <strong>Privacy</strong> for profile fields).</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong> then <strong>Personal details</strong> then <strong>Contact info</strong>.</li>
+          <li>Add/verify email or phone then set to <strong>Only me</strong> in your profile&#x27;s audience controls.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Use a private recovery email that isn&#x27;t publicly visible on your profile.</p>
+    </section>
+    <section class="card" id="guide-add-a-hardware-security-key">
+      <h2>Add a Hardware Security Key</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Two-factor authentication</strong>.</li>
+          <li>Choose <strong>Add security key</strong> then insert or tap your key when prompted then name it then <strong>Save</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings</strong> then <strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Two-factor authentication</strong> then <strong>Add security key</strong> then follow prompts.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Keep a spare key stored safely in case you lose one.</p>
+    </section>
+    <section class="card" id="guide-remove-remembered-devices-2fa">
+      <h2>Remove Remembered Devices (2FA)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Accounts Center</strong> then <strong>Password and security</strong> then <strong>Two-factor authentication</strong> then <strong>Remembered devices</strong>.</li>
+          <li>Click <strong>Remove</strong> next to any device you don&#x27;t control.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same path then remove remembered devices.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Always remove devices after using a public/shared computer.</p>
+    </section>
+    <section class="card" id="guide-clear-saved-logins-on-shared-devices">
+      <h2>Clear Saved Logins on Shared Devices</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>On the Facebook login screen, uncheck <strong>Keep me signed in</strong>.</li>
+          <li>In your browser&#x27;s <strong>Password/Autofill</strong> settings, delete any saved Facebook entries.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open your device <strong>Password manager</strong> (iOS Keychain / Android Google Password Manager).</li>
+          <li>Search for <strong>facebook.com</strong> then delete saved credentials.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Avoid saving credentials on borrowed or shared devices.</p>
+    </section>
+    <section class="card" id="guide-recognize-avoid-phishing">
+      <h2>Recognize &amp; Avoid Phishing</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Open <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Security and login</strong> to check <strong>official</strong> alerts.</li>
+          <li>Ignore emails/SMS asking for passwords or codes; instead, go directly to <strong>facebook.com</strong> and check <strong>Security and login</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Security and login</strong> for official alerts.</li>
+          <li>Never send codes/links in Messenger/DMs.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Meta will not ask for your password via email/text.</p>
+    </section>
+    <section class="card" id="guide-set-default-audience-for-future-posts">
+      <h2>Set Default Audience for Future Posts</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>facebook.com</strong> then <strong>profile picture (top-right)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong>.</li>
+          <li>Left sidebar: <strong>Privacy</strong> or <strong>Audience and visibility</strong> then <strong>Posts</strong>.</li>
+          <li><strong>Who can see your future posts?</strong> then choose <strong>Friends</strong> or <strong>Only me</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Audience and visibility</strong> then <strong>Posts</strong>.</li>
+          <li>Tap <strong>Who can see your future posts?</strong> then select <strong>Friends</strong>/<strong>Only me</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> This sets the default for new posts (you can still change per-post).</p>
+    </section>
+    <section class="card" id="guide-limit-past-post-audience-bulk">
+      <h2>Limit Past Post Audience (Bulk)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Audience and visibility</strong> then <strong>Posts</strong>.</li>
+          <li>Click <strong>Limit who can see past posts</strong> then read the warning then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same path then <strong>Limit who can see past posts</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Changes old Public/Friends-of-friends posts to <strong>Friends</strong>.</p>
+    </section>
+    <section class="card" id="guide-hide-your-friends-list">
+      <h2>Hide Your Friends List</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Audience and visibility</strong> then <strong>How people find and contact you</strong>.</li>
+          <li><strong>Who can see your Friends list?</strong> then choose <strong>Only me</strong> (recommended) or <strong>Friends</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same then set to <strong>Only me</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Hides your social graph from strangers and scrapers.</p>
+    </section>
+    <section class="card" id="guide-restrict-friend-requests">
+      <h2>Restrict Friend Requests</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>How people find and contact you</strong>.</li>
+          <li><strong>Who can send you friend requests?</strong> then <strong>Friends of friends</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Reduces spam/fake requests.</p>
+    </section>
+    <section class="card" id="guide-restrict-lookup-by-email">
+      <h2>Restrict Lookup by Email</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>How people find and contact you</strong>.</li>
+          <li><strong>Who can look you up using the email address you provided?</strong> then <strong>Only me</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Prevents data-broker matching.</p>
+    </section>
+    <section class="card" id="guide-restrict-lookup-by-phone-number">
+      <h2>Restrict Lookup by Phone Number</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Same page as #15 then set to <strong>Only me</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> If you use your real number, this is essential.</p>
+    </section>
+    <section class="card" id="guide-disable-search-engine-linking-to-your-profile">
+      <h2>Disable Search-Engine Linking to Your Profile</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>How people find and contact you</strong>.</li>
+          <li>Toggle off <strong>Do you want search engines outside of Facebook to link to your profile?</strong></li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Removes your profile from Google/Bing search results.</p>
+    </section>
+    <section class="card" id="guide-hide-active-status-facebook-messenger">
+      <h2>Hide Active Status (Facebook &amp; Messenger)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Click the <strong>Messenger icon (top-right speech bubble)</strong> then <strong>...</strong> then <strong>Active Status</strong>.</li>
+          <li>Toggle <strong>Show when you&#x27;re active</strong> then <strong>Off</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Settings</strong> then <strong>Active Status</strong>.</li>
+          <li>Toggle <strong>Show when you&#x27;re active</strong> then <strong>Off</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Others won&#x27;t see when you&#x27;re online.</p>
+    </section>
+    <section class="card" id="guide-turn-on-timeline-review-approve-posts-you-re-tagged-in">
+      <h2>Turn On Timeline Review (Approve Posts You&#x27;re Tagged In)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Profile and tagging</strong>.</li>
+          <li>Enable <strong>Review posts you&#x27;re tagged in before the post appears on your profile</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Prevents surprise content appearing on your timeline.</p>
+    </section>
+    <section class="card" id="guide-turn-on-tag-review-approve-tags-people-add">
+      <h2>Turn On Tag Review (Approve Tags People Add)</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Profile and tagging</strong>.</li>
+          <li>Enable <strong>Review tags people add to your posts before the tags appear</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Gives you veto power over tags.</p>
+    </section>
+    <section class="card" id="guide-restrict-who-can-post-on-your-profile">
+      <h2>Restrict Who Can Post on Your Profile</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Profile and tagging</strong>.</li>
+          <li><strong>Who can post on your profile?</strong> then <strong>Only you</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Stops others from posting directly to your timeline.</p>
+    </section>
+    <section class="card" id="guide-limit-comments-on-your-public-posts">
+      <h2>Limit Comments on Your Public Posts</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Settings</strong> then <strong>Audience and visibility</strong> then <strong>Public posts</strong>.</li>
+          <li><strong>Who can comment on your public posts?</strong> then <strong>Friends</strong> or <strong>Profiles you mention</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Same.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Reduces spam and harassment on public content.</p>
+    </section>
+    <section class="card" id="guide-delete-a-post">
+      <h2>Delete a Post</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Go to <strong>facebook.com</strong> then click your <strong>name</strong> to open your <strong>Profile</strong>.</li>
+          <li>Scroll to the post then click <strong>... (top-right of the post)</strong> then <strong>Move to trash</strong> or <strong>Delete</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App then tap your <strong>profile picture</strong> or <strong>name</strong> to open <strong>Profile</strong>.</li>
+          <li>Find the post then tap <strong>... (top-right of the post card)</strong> then <strong>Delete</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Items in Trash auto-delete after ~30 days unless you empty Trash sooner.</p>
+    </section>
+    <section class="card" id="guide-delete-a-photo">
+      <h2>Delete a Photo</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Profile</strong> then <strong>Photos</strong> (tabs under your cover area) then <strong>Your photos</strong>.</li>
+          <li>Click a photo to open it then click <strong>...</strong> (top-right of the photo) then <strong>Delete photo</strong> then <strong>Delete</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li><strong>Profile</strong> then scroll to <strong>Photos</strong> then <strong>Uploads</strong>.</li>
+          <li>Tap a photo then <strong>...</strong> (top-right) then <strong>Delete photo</strong> then <strong>Delete</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Deleting removes the photo, comments, reactions, and tags tied to it.</p>
+    </section>
+    <section class="card" id="guide-remove-your-tag-from-a-photo-or-post">
+      <h2>Remove Your Tag from a Photo or Post</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Open the tagged post/photo (it will say &quot;You&#x27;re tagged&quot;).</li>
+          <li>Click <strong>...</strong> (top-right of the post/photo) then <strong>Remove tag</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open the tagged content then tap <strong>...</strong> then <strong>Remove tag</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> This stops the item from appearing on your profile; it does not delete the original.</p>
+    </section>
+    <section class="card" id="guide-delete-a-comment-you-made">
+      <h2>Delete a Comment You Made</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Go to the post with your comment.</li>
+          <li>Hover over your comment then click <strong>...</strong> (to the right) then <strong>Delete</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open the post then find your comment then <strong>press and hold</strong> the comment.</li>
+          <li>Tap <strong>Delete</strong> then <strong>Confirm</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Deleting is permanent; you can also <strong>Edit</strong> instead.</p>
+    </section>
+    <section class="card" id="guide-remove-a-reaction-or-unlike-a-post">
+      <h2>Remove a Reaction or Unlike a Post</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li>Open the post then click your <strong>reaction icon</strong> again (it toggles off), or</li>
+          <li><strong>Profile</strong> then <strong>Settings &amp; privacy</strong> then <strong>Activity log</strong> then <strong>Interactions then Likes and reactions</strong> then remove entries.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open the post then tap your <strong>reaction</strong> again to remove.</li>
+          <li>Or <strong>Menu (=)</strong> then <strong>Settings &amp; privacy</strong> then <strong>Activity log</strong> then remove reactions.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Clean up old reactions to reduce your visible activity trail.</p>
+    </section>
+    <section class="card" id="guide-remove-check-ins-and-location-tags">
+      <h2>Remove Check-Ins and Location Tags</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Profile</strong> then <strong>Settings &amp; privacy</strong> then <strong>Activity log</strong>.</li>
+          <li>In the left filters, open <strong>Logged actions/Location history</strong> then delete check-ins or edit posts to remove locations.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>Open the post with the location tag then <strong>...</strong> then <strong>Edit post</strong> then remove the location (pin icon) then <strong>Save</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Also review your device&#x27;s location permissions for Facebook (see later guides).</p>
+    </section>
+    <section class="card" id="guide-archive-or-delete-old-stories">
+      <h2>Archive or Delete Old Stories</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Profile</strong> then click your <strong>profile picture</strong> then <strong>Story Archive</strong>.</li>
+          <li>Open a story then <strong>...</strong> (top-right) then <strong>Delete</strong> (or leave it archived).</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li>App home then tap your <strong>profile picture</strong> (or <strong>Your story</strong>) then <strong>Archive</strong>.</li>
+          <li>Open a story then <strong>...</strong> then <strong>Delete</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Stories vanish after 24h but live on in <strong>Archive</strong> until you delete them.</p>
+    </section>
+    <section class="card" id="guide-review-and-lock-down-albums">
+      <h2>Review and Lock Down Albums</h2>
+      <details open>
+        <summary>On Desktop</summary>
+        <ol>
+          <li><strong>Profile</strong> then <strong>Photos</strong> then <strong>Albums</strong>.</li>
+          <li>Hover an album then click <strong>...</strong> or <strong>Edit</strong> then set <strong>Audience</strong> to <strong>Friends</strong>/<strong>Only me</strong> then <strong>Save</strong>.</li>
+        </ol>
+      </details>
+      <details>
+        <summary>On Mobile</summary>
+        <ol>
+          <li><strong>Profile</strong> then <strong>Photos</strong> then <strong>Albums</strong> then open an album then <strong>...</strong> then <strong>Edit</strong> then <strong>Audience</strong> then choose <strong>Friends</strong>/<strong>Only me</strong> then <strong>Save</strong>.</li>
+        </ol>
+      </details>
+      <p class="lead"><strong>Tips:</strong> Pay special attention to old albums and default albums (e.g., Profile Pictures, Cover Photos).</p>
+    </section>
+    <!-- FB_GUIDES_END -->
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- replace the Facebook quick-start placeholder with a navigation primer, table of contents, and 30 detailed privacy guides between the FB guide markers
- add spacing and list padding rules so the new guide cards render consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de804bb118832399d639865193ab1e