### PR TITLE
Add About page (+ menu link, breadcrumbs, SEO) — no content changes to guides

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0b0f14">
+  <title>About — Facebook Privacy Master Guide</title>
+  <meta name="description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
+  <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/about/">
+  <meta property="og:title" content="About — Facebook Privacy Master Guide">
+  <meta property="og:description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/PRIVACY/about/">
+  <meta property="og:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
+  <meta property="og:site_name" content="Facebook Privacy Master Guide">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About — Facebook Privacy Master Guide">
+  <meta name="twitter:description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
+  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://osintsecrets.github.io/PRIVACY/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "About",
+        "item": "https://osintsecrets.github.io/PRIVACY/about/"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a class="skip" href="#main">Skip to content</a>
+    <div class="wrapper header-row">
+      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+        </nav>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <div class="wrapper">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="/PRIVACY/">Home</a></li>
+          <li aria-current="page">About</li>
+        </ol>
+      </nav>
+      <h1>About this guide</h1>
+      <p class="lead">Placeholder: A quick overview of why the Facebook Privacy Master Guide exists and how it supports safer digital habits.</p>
+      <section class="card">
+        <h2>Coming soon</h2>
+        <p>This section will be replaced with the full story behind the guide, how it is maintained, and ways to get involved.</p>
+      </section>
+    </div>
+  </main>
+  <footer>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
+  </footer>
+  <script src="/PRIVACY/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -38,6 +38,10 @@ summary{cursor:pointer;font-weight:600;}
 summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:10px;}
 footer{border-top:1px solid var(--border);color:#85b6bd;background:#0c1117;}
 footer .wrapper{padding-top:var(--space);padding-bottom:var(--space);font-size:0.9rem;}
+.footer-layout{display:flex;flex-direction:column;gap:12px;}
+.footer-links{display:flex;flex-wrap:wrap;gap:12px;}
+.footer-links a{color:var(--muted);text-decoration:none;}
+.footer-links a:hover{text-decoration:underline;}
 :root[data-rm='on'] *,[data-rm='on'] *{transition:none!important;animation:none!important;}
 .lead{ color:var(--muted); margin-bottom: var(--space); }
 .grid{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: var(--space); }
@@ -48,6 +52,13 @@ footer .wrapper{padding-top:var(--space);padding-bottom:var(--space);font-size:0
 .crumbs{ margin-bottom: var(--space); }
 .crumb.back{ display:inline-block; padding:8px 10px; border-radius:10px; border:1px solid var(--border); background:#0e1820; color:var(--text); text-decoration:none; }
 .crumb.back:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+.breadcrumb{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; font-size:0.95rem; color:var(--muted); margin-bottom:var(--space); }
+.breadcrumb ol{ display:flex; flex-wrap:wrap; gap:8px; list-style:none; margin:0; padding:0; }
+.breadcrumb ol li{ display:flex; align-items:center; gap:8px; }
+.breadcrumb ol li+li::before{ content:'/'; color:var(--muted); }
+.breadcrumb a{ color:var(--muted); text-decoration:none; }
+.breadcrumb a:hover{ text-decoration:underline; }
+.breadcrumb [aria-current="page"]{ color:var(--text); font-weight:600; }
 .card h2 + .lead { margin-top: .5rem; }
 .card details { margin-top: .75rem; }
 .card details + details { margin-top: .5rem; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -32,6 +32,8 @@
     '/PRIVACY/platforms/tiktok.html': 'platform',
     '/PRIVACY/platforms/whatsapp.html': 'platform',
     '/PRIVACY/platforms/telegram.html': 'platform',
+    '/PRIVACY/about/': 'about',
+    '/PRIVACY/about/index.html': 'about',
     '/PRIVACY/ethics.html': 'ethics',
     '/PRIVACY/why.html': 'why'
   };

--- a/ethics.html
+++ b/ethics.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -44,8 +45,14 @@
     </div>
   </main>
   <footer>
-    <div class="wrapper">
+    <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
     </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -29,7 +30,14 @@
     </section>
   </main>
   <footer>
-    <div class="wrapper"></div>
+    <div class="wrapper footer-layout">
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>

--- a/platform.html
+++ b/platform.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -37,8 +38,14 @@
     </section>
   </main>
   <footer>
-    <div class="wrapper">
+    <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
     </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -3411,7 +3412,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -47,7 +48,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -47,7 +48,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -47,7 +48,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -47,7 +48,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -47,7 +48,15 @@
   </main>
 
   <footer>
-    <div class="wrapper">Utility-first build — no trackers.</div>
+    <div class="wrapper footer-layout">
+      <p>Utility-first build — no trackers.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="/PRIVACY/assets/js/main.js" defer></script>

--- a/why.html
+++ b/why.html
@@ -16,6 +16,7 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
@@ -36,8 +37,14 @@
     </div>
   </main>
   <footer>
-    <div class="wrapper">
+    <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+      </nav>
     </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>


### PR DESCRIPTION
## Summary
- add a new About page with breadcrumb trail, placeholder copy, and social meta tags
- update the site navigation and footer links to surface the About page across the experience
- extend shared styles and scripts for breadcrumb presentation and About link highlighting

## Testing
- not run (static content site)


------
https://chatgpt.com/codex/tasks/task_e_68deb21f1de08323a0f6477b366e125b