### PR TITLE
Revise About page for OSINT Secrets narrative

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,88 +1,70 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#0b0f14">
-  <title>About — Facebook Privacy Master Guide</title>
-  <meta name="description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
-  <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/about/">
-  <meta property="og:title" content="About — Facebook Privacy Master Guide">
-  <meta property="og:description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>About — OSINT Secrets</title>
+  <meta name="description" content="Learn the mission behind OSINT Secrets and how it helps people protect their privacy and security online.">
+  <link rel="canonical" href="/PRIVACY/about/">
+  <meta property="og:title" content="About — OSINT Secrets">
+  <meta property="og:description" content="Learn the mission behind OSINT Secrets and how it helps people protect their privacy and security online.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://osintsecrets.github.io/PRIVACY/about/">
   <meta property="og:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
-  <meta property="og:site_name" content="Facebook Privacy Master Guide">
+  <meta property="og:site_name" content="OSINT Secrets">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="About — Facebook Privacy Master Guide">
-  <meta name="twitter:description" content="Learn the mission behind the Facebook Privacy Master Guide and how to use it.">
+  <meta name="twitter:title" content="About — OSINT Secrets">
+  <meta name="twitter:description" content="Learn the mission behind OSINT Secrets and how it helps people protect their privacy and security online.">
   <meta name="twitter:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-      {
-        "@type": "ListItem",
-        "position": 1,
-        "name": "Home",
-        "item": "https://osintsecrets.github.io/PRIVACY/"
-      },
-      {
-        "@type": "ListItem",
-        "position": 2,
-        "name": "About",
-        "item": "https://osintsecrets.github.io/PRIVACY/about/"
-      }
-    ]
-  }
-  </script>
 </head>
 <body>
   <header>
-    <a class="skip" href="#main">Skip to content</a>
-    <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
-      <div class="menu-container">
-        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
-        <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-        </nav>
-      </div>
-    </div>
+    <nav>
+      <a href="/PRIVACY/">Home</a>
+      <a href="/PRIVACY/platform.html">Platform</a>
+      <a href="/PRIVACY/about/" aria-current="page">About</a>
+    </nav>
   </header>
-  <main id="main">
-    <div class="wrapper">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
-        <ol>
-          <li><a href="/PRIVACY/">Home</a></li>
-          <li aria-current="page">About</li>
-        </ol>
-      </nav>
-      <h1>About this guide</h1>
-      <p class="lead">Placeholder: A quick overview of why the Facebook Privacy Master Guide exists and how it supports safer digital habits.</p>
-      <section class="card">
-        <h2>Coming soon</h2>
-        <p>This section will be replaced with the full story behind the guide, how it is maintained, and ways to get involved.</p>
-      </section>
-    </div>
+
+  <main>
+    <h1>About OSINT Secrets</h1>
+
+    <h2>Where It All Began</h2>
+    <p>It started with nothing more than curiosity. One day, I stumbled across a conversation between Griffin Glynn and Micah Hoffman on David Bombal’s channel — and something inside me lit up...</p>
+
+    <h2>The Darkness Beneath the Surface</h2>
+    <p>OSINT isn’t always about finding fun facts or solving harmless puzzles. If you follow the threads long enough, they eventually lead somewhere darker...</p>
+
+    <h2>The Protector Instinct</h2>
+    <p>That brush with the uglier side of humanity changed something in me. It awakened a different instinct — one I didn’t expect...</p>
+
+    <h2>Fighting Apathy With Purpose</h2>
+    <p>One of the hardest things I still struggle with is how little people care about privacy...</p>
+
+    <h2>My Mission Today</h2>
+    <p>In the beginning, I thought my role in OSINT would be to chase the bad guys — to dig into the darkness and fight it head-on. But I know now that my purpose is something different...</p>
+    <ol>
+      <li><strong>Privacy is sacred.</strong> Just because something is public doesn’t mean it’s free to exploit.</li>
+      <li><strong>We are not vigilantes.</strong> Our job is to inform and protect, not to punish.</li>
+      <li><strong>Knowledge must serve people.</strong> Power means nothing if it isn’t used responsibly.</li>
+    </ol>
+
+    <h2>Why I Stay Anonymous</h2>
+    <p>From the very beginning, I chose not to attach my real name to OSINT Secrets...</p>
+
+    <h2>The Road Ahead</h2>
+    <p>OSINT is a journey with no finish line. It’s constantly evolving — new platforms, new tools, new threats...</p>
+    <p><strong>“Not on my watch.”</strong></p>
   </main>
+
   <footer>
-    <div class="wrapper footer-layout">
-      <p>Utility-first build — no trackers.</p>
-      <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-      </nav>
-    </div>
+    <nav>
+      <a href="/PRIVACY/">Home</a>
+      <a href="/PRIVACY/platform.html">Platform</a>
+      <a href="/PRIVACY/about/" aria-current="page">About</a>
+    </nav>
+    <p>© 2025 OSINT Secrets</p>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the placeholder About content with the OSINT Secrets origin story and mission statements
- update document metadata for the new About page branding and description
- simplify the header and footer navigation to reflect the OSINT Secrets pages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68defaf1da0c8323ae277b5df849039b