### PR TITLE
Add Disclaimer page + reorder nav (no binaries, no guide changes)

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -20,14 +20,26 @@
 </head>
 <body>
   <header>
-    <nav>
-      <a href="/PRIVACY/">Home</a>
-      <a href="/PRIVACY/platform.html">Platform</a>
-      <a href="/PRIVACY/about/" aria-current="page">About</a>
-    </nav>
+    <a class="skip" href="#main">Skip to content</a>
+    <div class="wrapper header-row">
+      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+        </nav>
+      </div>
+    </div>
   </header>
 
-  <main>
+  <main id="main">
     <h1>About OSINT Secrets</h1>
 
     <h2>Where It All Began</h2>
@@ -90,12 +102,20 @@
   </main>
 
   <footer>
-    <nav>
-      <a href="/PRIVACY/">Home</a>
-      <a href="/PRIVACY/platform.html">Platform</a>
-      <a href="/PRIVACY/about/" aria-current="page">About</a>
-    </nav>
-    <p>© 2025 OSINT Secrets</p>
+    <div class="wrapper footer-layout">
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/" aria-current="page">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+      </nav>
+      <p>© 2025 OSINT Secrets</p>
+    </div>
   </footer>
+  <script src="/PRIVACY/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,21 +23,21 @@
   menu.addEventListener('keydown', (e)=>{ if(e.key==='Escape'){ toggle(false); btn.focus(); } });
   menu.querySelectorAll('a').forEach(a=> a.addEventListener('click', ()=> toggle(false)));
   // Mark current nav item
-  const map = {
-    '/PRIVACY/': 'home',
-    '/PRIVACY/platform.html': 'platform',
-    '/PRIVACY/platforms/facebook.html': 'platform',
-    '/PRIVACY/platforms/instagram.html': 'platform',
-    '/PRIVACY/platforms/x.html': 'platform',
-    '/PRIVACY/platforms/tiktok.html': 'platform',
-    '/PRIVACY/platforms/whatsapp.html': 'platform',
-    '/PRIVACY/platforms/telegram.html': 'platform',
-    '/PRIVACY/about/': 'about',
-    '/PRIVACY/about/index.html': 'about',
-    '/PRIVACY/ethics.html': 'ethics',
-    '/PRIVACY/why.html': 'why'
-  };
-  const key = Object.keys(map).find(p => location.pathname.endsWith(p.replace('/PRIVACY','')) || location.pathname===p);
-  const sel = key ? `[data-nav="${map[key]}"]` : null;
-  if (sel) document.querySelector(sel)?.setAttribute('aria-current','page');
+  const normalized = location.pathname.replace(/\/index\.html$/, '/');
+  let current = null;
+  const hash = location.hash;
+  if (hash === '#self-audit') current = 'self-audit';
+  else if (hash === '#tools-methods') current = 'tools';
+  if (!current) {
+    if (normalized === '/PRIVACY/' || normalized === '/PRIVACY') current = 'home';
+    else if (normalized === '/PRIVACY/self-audit/' || normalized === '/PRIVACY/self-audit') current = 'self-audit';
+    else if (normalized === '/PRIVACY/tools-and-methods/' || normalized === '/PRIVACY/tools-and-methods') current = 'tools';
+    else if (normalized === '/PRIVACY/platform.html') current = 'platform';
+    else if (normalized.startsWith('/PRIVACY/platforms/')) current = 'platform';
+    else if (normalized === '/PRIVACY/ethics.html') current = 'ethics';
+    else if (normalized === '/PRIVACY/why.html') current = 'why';
+    else if (normalized === '/PRIVACY/about/' || normalized === '/PRIVACY/about') current = 'about';
+    else if (normalized === '/PRIVACY/disclaimer/' || normalized === '/PRIVACY/disclaimer') current = 'disclaimer';
+  }
+  if (current) document.querySelector(`[data-nav="${current}"]`)?.setAttribute('aria-current','page');
 })();

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0b0f14">
+  <title>Disclaimer — OSINT Secrets</title>
+  <meta name="description" content="Important legal disclaimer for OSINT Secrets: educational purposes only.">
+  <link rel="canonical" href="/PRIVACY/disclaimer/">
+  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://osintsecrets.github.io/PRIVACY/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Disclaimer",
+        "item": "https://osintsecrets.github.io/PRIVACY/disclaimer/"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a class="skip" href="#main">Skip to content</a>
+    <div class="wrapper header-row">
+      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="/PRIVACY/" data-nav="home">Home</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
+          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
+          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+        </nav>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrapper">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/PRIVACY/">Home</a></li>
+        <li aria-current="page">Disclaimer</li>
+      </ol>
+    </nav>
+
+    <article class="card">
+      <h1>Disclaimer</h1>
+      <p>This site provides educational information intended to help you understand privacy risks, self-audit your digital footprint, and adopt safer habits. It is not legal advice, and it should not be treated as a substitute for professional counsel tailored to your specific situation.</p>
+      <p>Every action you take based on the material presented here is solely your responsibility. Laws, platform policies, and enforcement practices change quickly, and the examples offered may no longer apply in your jurisdiction or to your account. Always verify current requirements before acting.</p>
+      <p>Neither OSINT Secrets nor its contributors guarantee outcomes or assume liability for harm, loss, or disputes that arise from applying these suggestions. You decide whether, when, and how to act, and you accept full accountability for those choices.</p>
+      <p>If you need legal, security, or mental health support, consult licensed professionals who can evaluate your circumstances directly. Continuing to use this site means you understand and accept these terms.</p>
+    </article>
+  </main>
+
+  <footer>
+    <div class="wrapper footer-layout">
+      <nav class="footer-links" aria-label="Footer">
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
+        <a href="/PRIVACY/ethics.html">Ethics</a>
+        <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/" aria-current="page">Disclaimer</a>
+      </nav>
+      <p>Built for privacy-first research and education.</p>
+    </div>
+  </footer>
+  <script src="/PRIVACY/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/ethics.html
+++ b/ethics.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -90,10 +93,14 @@
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -16,26 +16,33 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
   </header>
   <main id="main">
-    <section class="wrapper">
+    <section id="self-audit" class="wrapper">
       <h1>Privacy is not something that is given to you — be the master of your privacy.</h1>
     </section>
   </main>
   <footer>
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platform.html
+++ b/platform.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -28,7 +31,7 @@
     <h1>Choose a Platform</h1>
     <p class="lead">Pick a platform to see practical privacy steps.</p>
 
-    <section class="grid" aria-label="Platforms">
+    <section id="tools-methods" class="grid" aria-label="Platforms">
       <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
       <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
       <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
@@ -41,10 +44,14 @@
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -17,10 +17,13 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="/PRIVACY/">Home</a>
-<a data-nav="about" href="/PRIVACY/about/">About</a>
+<a data-nav="self-audit" href="/PRIVACY/index.html#self-audit">Self-audit</a>
+<a data-nav="tools" href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="/PRIVACY/platform.html">Platform</a>
 <a data-nav="ethics" href="/PRIVACY/ethics.html">Ethics</a>
 <a data-nav="why" href="/PRIVACY/why.html">Why</a>
+<a data-nav="about" href="/PRIVACY/about/">About</a>
+<a data-nav="disclaimer" href="/PRIVACY/disclaimer/">Disclaimer</a>
 </nav>
 </div>
 </div>
@@ -3455,10 +3458,14 @@
 <div class="wrapper footer-layout">
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
-<a href="/PRIVACY/about/">About</a>
-<a href="/PRIVACY/platform.html">Platforms</a>
+<a href="/PRIVACY/">Home</a>
+<a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+<a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+<a href="/PRIVACY/platform.html">Platform</a>
 <a href="/PRIVACY/ethics.html">Ethics</a>
 <a href="/PRIVACY/why.html">Why</a>
+<a href="/PRIVACY/about/">About</a>
+<a href="/PRIVACY/disclaimer/">Disclaimer</a>
 </nav>
 </div>
 </footer>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -51,10 +54,14 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -51,10 +54,14 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -51,10 +54,14 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -51,10 +54,14 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -51,10 +54,14 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>

--- a/why.html
+++ b/why.html
@@ -16,10 +16,13 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
           <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
           <a href="/PRIVACY/why.html" data-nav="why">Why</a>
+          <a href="/PRIVACY/about/" data-nav="about">About</a>
+          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -54,10 +57,14 @@
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/platform.html">Platforms</a>
+        <a href="/PRIVACY/">Home</a>
+        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
+        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
+        <a href="/PRIVACY/platform.html">Platform</a>
         <a href="/PRIVACY/ethics.html">Ethics</a>
         <a href="/PRIVACY/why.html">Why</a>
+        <a href="/PRIVACY/about/">About</a>
+        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- add a dedicated Disclaimer page with breadcrumb markup, canonical metadata, and placeholder legal copy
- reorder the sitewide header and footer navigation to Home → Self-audit → Tools and Methods → Platform → Ethics → Why → About → Disclaimer
- update the navigation script and supporting anchors so the new items receive the correct active state, including hash-based targets

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68df52ab6140832393408d21b83092a1