### PR TITLE
Add ethical access gate and badge

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -17,8 +17,38 @@
   <meta name="twitter:description" content="Discover the story, mission, and guiding principles behind OSINT Secrets and its focus on privacy and protection.">
   <meta name="twitter:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="/ethics-badge.css">
+  <style>
+    .ethics-footer-note {
+      margin-top: 0.75rem;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.7);
+    }
+    .ethics-footer-note a {
+      color: inherit;
+      font-weight: 600;
+    }
+    .noscript-warning {
+      margin: 0;
+      padding: 0.75rem 1rem;
+      text-align: center;
+      background: #d64045;
+      color: #fff;
+      font-weight: 600;
+    }
+  </style>
+  <script src="/pledge.js"></script>
+  <script>
+    if (!window.hasValidPledge || !window.hasValidPledge()) {
+      window.location.href = '/pledge.html';
+    }
+  </script>
+  <script defer src="/ethics-badge.js"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">This site requires JavaScript to enforce the Ethics Pledge.</div>
+  </noscript>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
@@ -114,8 +144,16 @@
         <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
       <p>© 2025 OSINT Secrets</p>
+      <p class="ethics-footer-note"><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', function () {
+      if (window.initEthicsBadge) {
+        window.initEthicsBadge();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/access-denied.html
+++ b/access-denied.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Access Denied — Ethics Pledge</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --bg-gradient: linear-gradient(140deg, #f6f8ff 0%, #f9eaff 45%, #e1f7ff 100%);
+      --text-color: #1f2933;
+      --muted-color: #51606f;
+      --card-bg: rgba(255, 255, 255, 0.8);
+      --card-border: rgba(255, 255, 255, 0.6);
+      --accent: #5b6cff;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-gradient: linear-gradient(140deg, #070b14 0%, #141d32 40%, #2a1440 100%);
+        --text-color: #f5f7ff;
+        --muted-color: #a7b3c6;
+        --card-bg: rgba(20, 28, 45, 0.82);
+        --card-border: rgba(142, 161, 255, 0.3);
+        --accent: #9fb4ff;
+      }
+    }
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: var(--font-family);
+      background: var(--bg-gradient);
+      color: var(--text-color);
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      text-align: center;
+    }
+    main {
+      max-width: 540px;
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      backdrop-filter: blur(18px);
+      border-radius: 28px;
+      padding: 2.5rem 2rem;
+      box-shadow: 0 24px 48px rgba(79, 114, 205, 0.18);
+    }
+    h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2rem, 4vw, 2.75rem);
+      letter-spacing: -0.02em;
+    }
+    p {
+      margin: 0 0 1rem;
+      line-height: 1.7;
+      color: var(--muted-color);
+      font-size: 1.05rem;
+    }
+    a.button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.8rem 1.6rem;
+      border-radius: 999px;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 600;
+      text-decoration: none;
+      box-shadow: 0 18px 32px rgba(91, 108, 255, 0.35);
+      margin: 0.5rem;
+    }
+    .links {
+      margin-top: 1.5rem;
+      font-size: 0.95rem;
+    }
+    .links a {
+      color: inherit;
+      font-weight: 600;
+    }
+    footer {
+      margin-top: 2rem;
+      font-size: 0.9rem;
+      color: var(--muted-color);
+    }
+    footer a {
+      color: inherit;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <noscript>
+    <div style="background:#d64045;color:#fff;padding:0.75rem 1rem;border-radius:12px;margin-bottom:1.5rem;font-weight:600;">This site requires JavaScript to enforce the Ethics Pledge.</div>
+  </noscript>
+  <main>
+    <h1>Ethics Required</h1>
+    <p>Thanks for taking a moment to reflect. Because you chose not to accept the Ethical Access Pledge, this site is unavailable to you. That’s okay — boundaries protect everyone.</p>
+    <p>If you change your mind, you can review the pledge any time and regain access by agreeing to uphold it.</p>
+    <div>
+      <a class="button" href="/pledge.html">Review the Pledge</a>
+    </div>
+    <div class="links">
+      Learn more: <a href="/ethics.html">Ethics</a> • <a href="/disclaimer.html">Disclaimer</a>
+    </div>
+  </main>
+  <footer>
+    <p><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+  </footer>
+</body>
+</html>

--- a/ethics-badge.css
+++ b/ethics-badge.css
@@ -1,0 +1,151 @@
+.ethics-badge-container {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 1200;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.ethics-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.6rem 1rem;
+  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 16px 32px rgba(79, 114, 205, 0.25);
+}
+
+.ethics-badge button {
+  border: none;
+  background: transparent;
+  color: #334155;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.ethics-badge button:focus-visible {
+  outline: 3px solid rgba(91, 108, 255, 0.6);
+  outline-offset: 4px;
+  border-radius: 999px;
+}
+
+.ethics-badge svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.ethics-popover {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(240px, 90vw);
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(11, 21, 38, 0.92);
+  color: #e8edff;
+  box-shadow: 0 18px 42px rgba(10, 16, 45, 0.45);
+  border: 1px solid rgba(142, 161, 255, 0.28);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.ethics-popover[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.ethics-popover h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c5d1ff;
+}
+
+.ethics-popover ul {
+  margin: 0 0 0.75rem;
+  padding-left: 1.1rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.ethics-links {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  margin-bottom: 0.65rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.ethics-popover a {
+  color: #9fb4ff;
+  font-weight: 600;
+}
+
+.ethics-popover-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.78rem;
+  color: rgba(229, 234, 255, 0.7);
+  margin-top: 0.5rem;
+}
+
+.ethics-popover-close {
+  border: none;
+  background: rgba(229, 234, 255, 0.12);
+  color: #e9eeff;
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.ethics-popover-close:focus-visible {
+  outline: 2px solid rgba(159, 180, 255, 0.8);
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ethics-badge {
+    background: rgba(13, 23, 40, 0.85);
+    border-color: rgba(142, 161, 255, 0.3);
+    color: #c5d1ff;
+  }
+
+  .ethics-badge button {
+    color: #c5d1ff;
+  }
+}
+
+@media (max-width: 640px) {
+  .ethics-badge-container {
+    top: auto;
+    bottom: 1.5rem;
+    right: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ethics-popover {
+    transition: none;
+  }
+}

--- a/ethics-badge.js
+++ b/ethics-badge.js
@@ -1,0 +1,117 @@
+(function () {
+  function initEthicsBadge(options = {}) {
+    if (typeof document === 'undefined') return;
+    if (document.querySelector('.ethics-badge-container')) return;
+
+    const target = options.containerSelector ? document.querySelector(options.containerSelector) : document.body;
+    if (!target) return;
+
+    const container = document.createElement('div');
+    container.className = 'ethics-badge-container';
+    container.setAttribute('aria-live', 'polite');
+
+    const badge = document.createElement('div');
+    badge.className = 'ethics-badge';
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-controls', 'ethics-popover');
+    trigger.innerHTML = `
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20zm0 3.25a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5zm1 4.25h-2a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg>
+      Ethics-First
+    `;
+
+    const popover = document.createElement('div');
+    popover.className = 'ethics-popover';
+    popover.id = 'ethics-popover';
+    popover.setAttribute('role', 'dialog');
+    popover.setAttribute('aria-modal', 'false');
+    popover.setAttribute('aria-hidden', 'true');
+
+    popover.innerHTML = `
+      <h3>Ethics Reminder</h3>
+      <ul>
+        <li>Public ≠ Permission</li>
+        <li>No doxxing, ever</li>
+        <li>Use power to protect</li>
+      </ul>
+      <div class="ethics-links">
+        <a href="/ethics.html">Ethics Policy</a> · <a href="/disclaimer.html">Disclaimer</a>
+      </div>
+      <div class="ethics-popover-footer">
+        <span>Terms v1.0</span>
+        <button type="button" class="ethics-popover-close">Close</button>
+      </div>
+    `;
+
+    const closeButton = popover.querySelector('.ethics-popover-close');
+    const links = Array.from(popover.querySelectorAll('a'));
+
+    function getFocusableElements() {
+      return [closeButton, ...links].filter(Boolean);
+    }
+
+    let isOpen = false;
+
+    function setOpen(nextState) {
+      isOpen = nextState;
+      popover.dataset.open = String(isOpen);
+      popover.setAttribute('aria-hidden', String(!isOpen));
+      trigger.setAttribute('aria-expanded', String(isOpen));
+      if (isOpen) {
+        const focusable = getFocusableElements();
+        if (focusable.length) {
+          focusable[0].focus();
+        }
+        document.addEventListener('mousedown', handleOutsideClick);
+        document.addEventListener('keydown', handleKeydown);
+      } else {
+        document.removeEventListener('mousedown', handleOutsideClick);
+        document.removeEventListener('keydown', handleKeydown);
+        trigger.focus({ preventScroll: true });
+      }
+    }
+
+    function handleOutsideClick(event) {
+      if (!popover.contains(event.target) && event.target !== trigger) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeydown(event) {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+      if (event.key === 'Tab' && isOpen) {
+        const focusable = getFocusableElements();
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    trigger.addEventListener('click', () => {
+      setOpen(!isOpen);
+    });
+
+    closeButton?.addEventListener('click', () => setOpen(false));
+
+    badge.appendChild(trigger);
+    badge.appendChild(popover);
+    container.appendChild(badge);
+    target.appendChild(container);
+  }
+
+  if (typeof window !== 'undefined') {
+    window.initEthicsBadge = initEthicsBadge;
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -6,8 +6,38 @@
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Home</title>
   <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="/ethics-badge.css">
+  <style>
+    .ethics-footer-note {
+      margin-top: 1rem;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.7);
+    }
+    .ethics-footer-note a {
+      color: inherit;
+      font-weight: 600;
+    }
+    .noscript-warning {
+      margin: 0;
+      padding: 0.75rem 1rem;
+      text-align: center;
+      background: #d64045;
+      color: #fff;
+      font-weight: 600;
+    }
+  </style>
+  <script src="/pledge.js"></script>
+  <script>
+    if (!window.hasValidPledge || !window.hasValidPledge()) {
+      window.location.href = '/pledge.html';
+    }
+  </script>
+  <script defer src="/ethics-badge.js"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">This site requires JavaScript to enforce the Ethics Pledge.</div>
+  </noscript>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
@@ -44,8 +74,16 @@
         <a href="/PRIVACY/about/">About</a>
         <a href="/PRIVACY/disclaimer/">Disclaimer</a>
       </nav>
+      <p class="ethics-footer-note"><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
   <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', function () {
+      if (window.initEthicsBadge) {
+        window.initEthicsBadge();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/pledge.css
+++ b/pledge.css
@@ -1,0 +1,448 @@
+:root {
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg-gradient: linear-gradient(135deg, #f4f5ff 0%, #e3f7ff 40%, #f8e4ff 100%);
+  --card-bg: rgba(255, 255, 255, 0.8);
+  --card-border: rgba(255, 255, 255, 0.6);
+  --text-color: #1f2933;
+  --muted-color: #51606f;
+  --accent: #5b6cff;
+  --accent-strong: #414bff;
+  --danger: #d64045;
+  --shadow: 0 24px 48px rgba(79, 114, 205, 0.18);
+  --glass-blur: 22px;
+  --footer-bg: rgba(255, 255, 255, 0.6);
+  --chip-bg: rgba(91, 108, 255, 0.12);
+  --chip-text: #2b36a0;
+  --scrollbar: rgba(91, 108, 255, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-gradient: linear-gradient(135deg, #080c17 0%, #0f1b2d 45%, #1f1230 100%);
+    --card-bg: rgba(15, 22, 37, 0.78);
+    --card-border: rgba(79, 114, 205, 0.35);
+    --text-color: #f5f7ff;
+    --muted-color: #a7b3c6;
+    --accent: #8ea1ff;
+    --accent-strong: #b2c2ff;
+    --danger: #ff767d;
+    --shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+    --footer-bg: rgba(15, 22, 37, 0.65);
+    --chip-bg: rgba(142, 161, 255, 0.16);
+    --chip-text: #cfd7ff;
+    --scrollbar: rgba(142, 161, 255, 0.55);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--font-family);
+  background: var(--bg-gradient);
+  color: var(--text-color);
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: inherit;
+  filter: blur(60px);
+  transform: scale(1.02);
+  z-index: -2;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.3), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(91, 108, 255, 0.25), transparent 60%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.noscript-message {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  text-align: center;
+  background: var(--danger);
+  color: #fff;
+  font-weight: 600;
+}
+
+.pledge-shell {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 3rem);
+}
+
+.pledge-card {
+  width: min(920px, 100%);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  padding: clamp(2rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+}
+
+.pledge-header h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 3vw, 3rem);
+  letter-spacing: -0.02em;
+}
+
+.intro-tagline {
+  margin: 1rem 0 0;
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: var(--muted-color);
+}
+
+.intro-text {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--muted-color);
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.pane[hidden] {
+  display: none !important;
+}
+
+.pledge-scroll-card {
+  position: relative;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  max-height: clamp(260px, 40vh, 360px);
+  overflow-y: auto;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .pledge-scroll-card {
+    background: rgba(15, 22, 37, 0.78);
+    border-color: rgba(142, 161, 255, 0.25);
+  }
+}
+
+.pledge-scroll-card:focus-visible {
+  box-shadow: 0 0 0 3px rgba(91, 108, 255, 0.5);
+}
+
+.scroll-progress {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(91, 108, 255, 0.15);
+  margin: -1.5rem -1.5rem 1rem;
+}
+
+.scroll-progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.countdown-chip {
+  align-self: flex-end;
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  letter-spacing: 0.02em;
+}
+
+.pledge-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-color);
+  padding-right: 0.5rem;
+}
+
+.pledge-body p {
+  margin: 0;
+}
+
+.pledge-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.pledge-body::-webkit-scrollbar-thumb {
+  background: var(--scrollbar);
+  border-radius: 999px;
+}
+
+.checkbox-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.checkbox-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  .checkbox-option {
+    background: rgba(18, 27, 45, 0.78);
+    border-color: rgba(142, 161, 255, 0.2);
+  }
+}
+
+.checkbox-option:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(91, 108, 255, 0.15);
+}
+
+.checkbox-option:focus-within {
+  box-shadow: 0 0 0 3px rgba(91, 108, 255, 0.4);
+}
+
+.checkbox-option input[type="checkbox"] {
+  margin: 0.3rem 0 0;
+  appearance: none;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 6px;
+  border: 2px solid var(--accent);
+  background: transparent;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.checkbox-option input[type="checkbox"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(91, 108, 255, 0.35);
+}
+
+.checkbox-option input[type="checkbox"]:checked {
+  background: var(--accent);
+  border-color: var(--accent-strong);
+}
+
+.checkbox-option input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  inset: 0.2rem;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.pane-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.btn {
+  --btn-bg: rgba(91, 108, 255, 0.12);
+  --btn-color: var(--accent);
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  background: var(--btn-bg);
+  color: var(--btn-color);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.btn.primary {
+  --btn-bg: var(--accent);
+  --btn-color: #fff;
+  box-shadow: 0 18px 32px rgba(91, 108, 255, 0.35);
+}
+
+.btn.ghost {
+  --btn-bg: transparent;
+  --btn-color: var(--accent);
+  border: 1px solid rgba(91, 108, 255, 0.35);
+  box-shadow: none;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn[aria-disabled="true"],
+.btn.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn[aria-disabled="true"]:hover,
+.btn.is-disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.btn:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(91, 108, 255, 0.4);
+}
+
+.btn:not(:disabled):active {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(91, 108, 255, 0.35);
+}
+
+.link-negative {
+  color: var(--muted-color);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.tooltip {
+  font-size: 0.9rem;
+  color: var(--muted-color);
+}
+
+.helper-text {
+  color: var(--muted-color);
+  margin-top: -0.5rem;
+}
+
+.confirm-label {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  display: block;
+}
+
+#confirm-input {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(91, 108, 255, 0.35);
+  background: rgba(255, 255, 255, 0.75);
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  #confirm-input {
+    background: rgba(18, 27, 45, 0.75);
+    color: var(--text-color);
+  }
+}
+
+#confirm-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(91, 108, 255, 0.3);
+}
+
+.legal-line {
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  margin: 0;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 1.5rem;
+  background: var(--footer-bg);
+  font-size: 0.9rem;
+  color: var(--muted-color);
+}
+
+.site-footer a {
+  color: inherit;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .pledge-card {
+    border-radius: 24px;
+    padding: 2rem 1.5rem;
+  }
+
+  .pane-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn,
+  .link-negative {
+    width: 100%;
+    text-align: center;
+  }
+
+  .countdown-chip {
+    align-self: stretch;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/pledge.html
+++ b/pledge.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ethical Access Gate</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/pledge.css">
+  <link rel="stylesheet" href="/ethics-badge.css">
+  <script src="/pledge.js"></script>
+  <script defer src="/ethics-badge.js"></script>
+</head>
+<body data-pledge-page>
+  <noscript>
+    <div class="noscript-message">This site requires JavaScript to enforce the Ethics Pledge. Please enable JavaScript to continue.</div>
+  </noscript>
+  <main class="pledge-shell" role="main">
+    <section class="pledge-card" aria-live="polite">
+      <header class="pledge-header">
+        <h1 id="pane-title">Ethical Access Gate</h1>
+        <p class="intro-tagline">“This project exists to educate, protect, and empower — never to harm. Before you enter, please review and accept our ethical terms. The internet is already dark enough. Don’t make it darker.”</p>
+      </header>
+
+      <div class="pane" data-step="intro" aria-labelledby="pane-title" aria-describedby="intro-description">
+        <div id="intro-description" class="intro-text">Explore responsibly. Learn why our ethics matter on the <a href="/ethics.html">Ethics page</a> and review the <a href="/disclaimer.html">Disclaimer</a> before proceeding.</div>
+        <article class="pledge-scroll-card" aria-label="Pledge text" tabindex="0" data-scrollable>
+          <div class="scroll-progress" aria-hidden="true">
+            <div class="scroll-progress-bar" style="width:0%"></div>
+          </div>
+          <div class="countdown-chip" role="status" aria-live="polite"><span data-countdown>--</span> seconds remaining</div>
+          <div class="pledge-body">
+            <p>Ethical access means honoring the people, communities, and systems that make knowledge possible. You are about to enter a space that shares insights, research, and tools meant to uplift defenders and caretakers of privacy. With every technique you learn here comes the responsibility to wield it with empathy and restraint. The safeguards that protect one person should never become the weapons that dismantle another.</p>
+            <p>As you read, commit to pausing before you act. Ask whether each use respects consent, legality, and human dignity. Information can illuminate, but it can also expose. Our promise is to teach with integrity; your promise is to apply this learning with the same care. When in doubt, choose transparency, compassion, and protection.</p>
+            <p>This pledge is not a formality. It is a living ethic that keeps this project aligned with its purpose. If you cannot agree to uphold these values, you must exit now. If you can, take the time to read, reflect, and confirm. Together we can build a safer, kinder digital world.</p>
+          </div>
+        </article>
+        <p class="helper-text" data-scroll-hint>Scroll to the end and allow the timer to complete to enable the Continue button.</p>
+        <div class="pane-actions">
+          <button class="btn primary" data-action="to-checkboxes" disabled>
+            Continue
+          </button>
+          <a href="/access-denied.html" class="link-negative">No, I don’t agree</a>
+        </div>
+      </div>
+
+      <div class="pane" data-step="checkboxes" aria-labelledby="checkboxes-title" hidden>
+        <h2 id="checkboxes-title">Confirm your commitments</h2>
+        <form class="pledge-form" aria-describedby="checkboxes-note">
+          <p id="checkboxes-note">Please review each statement and acknowledge every one. Your choices are not tracked beyond this session.</p>
+          <ul class="checkbox-list">
+            <li>
+              <label class="checkbox-option">
+                <input type="checkbox" name="pledge" value="guidelines">
+                <span>I agree to follow the ethical guidelines described on this website.</span>
+              </label>
+            </li>
+            <li>
+              <label class="checkbox-option">
+                <input type="checkbox" name="pledge" value="malicious">
+                <span>I agree that I will not use any information from this site for malicious purposes.</span>
+              </label>
+            </li>
+            <li>
+              <label class="checkbox-option">
+                <input type="checkbox" name="pledge" value="doxxing">
+                <span>I agree that I will not use any information from this site to stalk, doxx, harass, scam, or spam anyone.</span>
+              </label>
+            </li>
+            <li>
+              <label class="checkbox-option">
+                <input type="checkbox" name="pledge" value="laws">
+                <span>I agree to use any tools, techniques, or methods discussed here lawfully and in compliance with my local laws.</span>
+              </label>
+            </li>
+            <li>
+              <label class="checkbox-option">
+                <input type="checkbox" name="pledge" value="responsibility">
+                <span>I am solely responsible for my actions and their consequences.</span>
+              </label>
+            </li>
+          </ul>
+        </form>
+        <div class="pane-actions">
+          <button class="btn ghost" data-action="back-to-intro">Back</button>
+          <button class="btn primary" data-action="to-confirm" aria-describedby="checkbox-tooltip">Next</button>
+          <span id="checkbox-tooltip" class="tooltip" role="status" aria-live="polite" hidden>You’ll be able to continue after checking every box.</span>
+        </div>
+      </div>
+
+      <div class="pane" data-step="confirm" aria-labelledby="confirm-title" hidden>
+        <h2 id="confirm-title">Final confirmation</h2>
+        <p>Type the following phrase exactly to confirm your understanding:</p>
+        <label class="confirm-label" for="confirm-input">I AGREE TO USE THIS ETHICALLY</label>
+        <input id="confirm-input" type="text" autocomplete="off" spellcheck="false" data-autofocus aria-describedby="confirm-helper">
+        <p id="confirm-helper" class="helper-text">Type the phrase exactly as shown above. Take your time — this isn’t a test, it’s a mindful pause.</p>
+        <p class="legal-line">“By continuing, you make a legally binding statement that you understand and agree to the above. If you do not agree, do not use this website.”</p>
+        <div class="pane-actions">
+          <button class="btn ghost" data-action="back-to-checkboxes">Back</button>
+          <button class="btn primary" data-action="complete" disabled>Create Session &amp; Enter Site</button>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+  </footer>
+</body>
+</html>

--- a/pledge.js
+++ b/pledge.js
@@ -1,0 +1,275 @@
+(function () {
+  const TERMS_VERSION = 'v1.0 (2025-10-03)';
+  const TOKEN_KEY = 'ETHICS_PLEDGE_TOKEN';
+  const CONFIRM_PHRASE = 'I AGREE TO USE THIS ETHICALLY';
+
+  function parseStoredToken(raw) {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn('Invalid pledge token payload', error);
+      return null;
+    }
+  }
+
+  function hasValidPledge() {
+    if (typeof window === 'undefined') return false;
+    try {
+      const stored = parseStoredToken(sessionStorage.getItem(TOKEN_KEY));
+      return Boolean(stored && stored.version === TERMS_VERSION && typeof stored.token === 'string' && stored.token.length > 0);
+    } catch (error) {
+      console.warn('Unable to read pledge token', error);
+      return false;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.hasValidPledge = hasValidPledge;
+    window.ETHICS_PLEDGE = Object.freeze({ TERMS_VERSION, TOKEN_KEY, hasValidPledge });
+  }
+
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function initPledgePage() {
+    const pageRoot = document.body;
+    if (!pageRoot || !pageRoot.hasAttribute('data-pledge-page')) return;
+
+    const countdownSpan = document.querySelector('[data-countdown]');
+    const countdownChip = countdownSpan ? countdownSpan.parentElement : null;
+    const countdownBar = document.querySelector('.scroll-progress-bar');
+    const continueButton = document.querySelector('[data-action="to-checkboxes"]');
+    const scrollable = document.querySelector('[data-scrollable]');
+    const scrollHint = document.querySelector('[data-scroll-hint]');
+    const panes = Array.from(document.querySelectorAll('.pane'));
+    const backToIntroButton = document.querySelector('[data-action="back-to-intro"]');
+    const toConfirmButton = document.querySelector('[data-action="to-confirm"]');
+    const backToCheckboxesButton = document.querySelector('[data-action="back-to-checkboxes"]');
+    const completeButton = document.querySelector('[data-action="complete"]');
+    const confirmInput = document.querySelector('#confirm-input');
+    const checkboxTooltip = document.querySelector('#checkbox-tooltip');
+    const checkboxes = Array.from(document.querySelectorAll('.checkbox-option input[type="checkbox"]'));
+
+    let countdownInterval = null;
+    const countdownSeconds = 8 + Math.floor(Math.random() * 5);
+    let secondsRemaining = countdownSeconds;
+    let countdownComplete = false;
+    let scrolledToBottom = false;
+    let tooltipTimeout = null;
+
+    function showPane(index) {
+      panes.forEach((pane, paneIndex) => {
+        const isActive = paneIndex === index;
+        pane.hidden = !isActive;
+        pane.setAttribute('aria-hidden', String(!isActive));
+        if (isActive) {
+          const focusTarget = pane.querySelector('[data-autofocus]') || pane.querySelector('button:not([disabled]), input:not([disabled]), a[href], textarea, select, [tabindex]:not([tabindex="-1"])');
+          if (focusTarget) {
+            requestAnimationFrame(() => focusTarget.focus({ preventScroll: true }));
+          }
+        }
+      });
+    }
+
+    function updateCountdownDisplay() {
+      if (countdownSpan) {
+        countdownSpan.textContent = secondsRemaining.toString().padStart(2, '0');
+      }
+      if (countdownBar) {
+        const progress = ((countdownSeconds - secondsRemaining) / countdownSeconds) * 100;
+        countdownBar.style.width = `${Math.min(progress, 100)}%`;
+      }
+    }
+
+    function maybeEnableContinue() {
+      if (!continueButton) return;
+      const ready = countdownComplete && scrolledToBottom;
+      continueButton.disabled = !ready;
+      continueButton.setAttribute('aria-disabled', String(!ready));
+      if (ready) {
+        continueButton.classList.add('is-ready');
+      }
+    }
+
+    function handleScroll() {
+      if (!scrollable) return;
+      const { scrollTop, scrollHeight, clientHeight } = scrollable;
+      const progress = (scrollTop + clientHeight) / scrollHeight;
+      if (progress >= 0.98) {
+        if (!scrolledToBottom) {
+          scrolledToBottom = true;
+          if (scrollHint) {
+            scrollHint.textContent = 'Thank you for reading — the timer will finish shortly.';
+          }
+          maybeEnableContinue();
+        }
+      } else {
+        scrolledToBottom = false;
+        if (scrollHint) {
+          scrollHint.textContent = 'Scroll to the end and allow the timer to complete to enable the Continue button.';
+        }
+        maybeEnableContinue();
+      }
+    }
+
+    function startCountdown() {
+      updateCountdownDisplay();
+      countdownInterval = window.setInterval(() => {
+        secondsRemaining = Math.max(0, secondsRemaining - 1);
+        updateCountdownDisplay();
+        if (secondsRemaining === 0) {
+          countdownComplete = true;
+          window.clearInterval(countdownInterval);
+          if (countdownChip) {
+            countdownChip.textContent = 'Timer complete';
+          }
+          maybeEnableContinue();
+        }
+      }, 1000);
+    }
+
+    function setAriaDisabled(button, isDisabled) {
+      if (!button) return;
+      button.setAttribute('aria-disabled', String(isDisabled));
+      button.classList.toggle('is-disabled', isDisabled);
+    }
+
+    function updateCheckboxState() {
+      const allChecked = checkboxes.every((box) => box.checked);
+      setAriaDisabled(toConfirmButton, !allChecked);
+      if (allChecked && checkboxTooltip) {
+        checkboxTooltip.hidden = true;
+      }
+    }
+
+    function showCheckboxTooltip() {
+      if (!checkboxTooltip) return;
+      checkboxTooltip.hidden = false;
+      if (tooltipTimeout) {
+        window.clearTimeout(tooltipTimeout);
+      }
+      tooltipTimeout = window.setTimeout(() => {
+        checkboxTooltip.hidden = true;
+      }, 3000);
+    }
+
+    function updateConfirmState() {
+      const matches = confirmInput && confirmInput.value.trim() === CONFIRM_PHRASE;
+      if (completeButton) {
+        completeButton.disabled = !matches;
+        completeButton.setAttribute('aria-disabled', String(!matches));
+      }
+    }
+
+    function generateToken() {
+      if (window.crypto && window.crypto.randomUUID) {
+        return window.crypto.randomUUID();
+      }
+      return `ethics-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+    }
+
+    function persistToken() {
+      const payload = { token: generateToken(), version: TERMS_VERSION, createdAt: new Date().toISOString() };
+      try {
+        sessionStorage.setItem(TOKEN_KEY, JSON.stringify(payload));
+      } catch (error) {
+        console.warn('Unable to store pledge token', error);
+      }
+    }
+
+    function completeFlow() {
+      persistToken();
+      window.location.href = '/index.html';
+    }
+
+    if (continueButton) {
+      continueButton.addEventListener('click', () => {
+        showPane(1);
+        const firstCheckbox = checkboxes[0];
+        if (firstCheckbox) {
+          requestAnimationFrame(() => firstCheckbox.focus({ preventScroll: true }));
+        }
+      });
+    }
+
+    if (backToIntroButton) {
+      backToIntroButton.addEventListener('click', () => {
+        showPane(0);
+        if (scrollable) {
+          requestAnimationFrame(() => scrollable.focus({ preventScroll: true }));
+        }
+      });
+    }
+
+    if (toConfirmButton) {
+      const handleAttempt = (event) => {
+        if (toConfirmButton.getAttribute('aria-disabled') === 'true') {
+          event.preventDefault();
+          showCheckboxTooltip();
+          return;
+        }
+        showPane(2);
+      };
+      toConfirmButton.addEventListener('click', handleAttempt);
+      toConfirmButton.addEventListener('keydown', (event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && toConfirmButton.getAttribute('aria-disabled') === 'true') {
+          event.preventDefault();
+          showCheckboxTooltip();
+        }
+      });
+    }
+
+    if (backToCheckboxesButton) {
+      backToCheckboxesButton.addEventListener('click', () => {
+        showPane(1);
+        if (checkboxes.length) {
+          requestAnimationFrame(() => checkboxes[0].focus({ preventScroll: true }));
+        }
+      });
+    }
+
+    if (completeButton) {
+      completeButton.addEventListener('click', () => {
+        if (completeButton.disabled) return;
+        completeFlow();
+      });
+    }
+
+    checkboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        updateCheckboxState();
+      });
+    });
+
+    if (confirmInput) {
+      confirmInput.addEventListener('input', updateConfirmState);
+    }
+
+    if (scrollable) {
+      scrollable.addEventListener('scroll', handleScroll, { passive: true });
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        showPane(0);
+        if (continueButton) {
+          requestAnimationFrame(() => continueButton.focus({ preventScroll: true }));
+        }
+      }
+    });
+
+    handleScroll();
+    updateCheckboxState();
+    updateConfirmState();
+    showPane(0);
+    startCountdown();
+  }
+
+  ready(initPledgePage);
+})();


### PR DESCRIPTION
## Summary
- introduce a full-page multi-step pledge gate with countdown, scroll acknowledgement, checkbox confirmations, and type-to-confirm to issue a session-scoped access token
- add a floating Ethics-First badge component with a popover reminder and hook it into the example pages alongside noscript messaging and the updated footer line
- provide an access denied fallback page and wire up redirect enforcement on index and about pages using the shared pledge helper

## Testing
- not run (static site updates)


------
https://chatgpt.com/codex/tasks/task_e_68df5d4910f08323ab1ba7bb4cc89eca