### PR TITLE
Restore disclaimer modal gate and use relative URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Page not found — Social Risk Audit</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
   <style>
     body { display:flex; align-items:center; justify-content:center; min-height:100vh; }
     main { text-align:center; }
@@ -15,7 +15,7 @@
   <main class="card">
     <h1>Page not found</h1>
     <p class="lead">The link you followed doesn’t exist. Return to the starting point to continue.</p>
-    <a class="button primary" href="/PRIVACY/">Back to Home</a>
+    <a class="button primary" href="./">Back to Home</a>
   </main>
 </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>About — OSINT Secrets</title>
   <meta name="description" content="Discover the story, mission, and guiding principles behind OSINT Secrets and its focus on privacy and protection.">
-  <link rel="canonical" href="/PRIVACY/about/">
+  <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/about/">
   <meta property="og:title" content="About — OSINT Secrets">
   <meta property="og:description" content="Discover the story, mission, and guiding principles behind OSINT Secrets and its focus on privacy and protection.">
   <meta property="og:type" content="website">
@@ -16,9 +16,9 @@
   <meta name="twitter:title" content="About — OSINT Secrets">
   <meta name="twitter:description" content="Discover the story, mission, and guiding principles behind OSINT Secrets and its focus on privacy and protection.">
   <meta name="twitter:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
-  <link rel="stylesheet" href="/PRIVACY/assets/css/site.css">
-  <link rel="stylesheet" href="/ethics-badge.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/site.css">
+  <link rel="stylesheet" href="../ethics-badge.css">
   <style>
     .ethics-footer-note {
       margin-top: 0.75rem;
@@ -38,13 +38,7 @@
       font-weight: 600;
     }
   </style>
-  <script src="/pledge.js"></script>
-  <script>
-    if (!window.hasValidPledge || !window.hasValidPledge()) {
-      window.location.href = '/pledge.html';
-    }
-  </script>
-  <script defer src="/ethics-badge.js"></script>
+  <script defer src="../ethics-badge.js"></script>
 </head>
 <body>
   <noscript>
@@ -53,18 +47,18 @@
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="./" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -143,21 +137,21 @@
   <footer>
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/" aria-current="page">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="./" aria-current="page">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
       <p>© 2025 OSINT Secrets</p>
-      <p class="ethics-footer-note"><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+      <p class="ethics-footer-note"><a href="../ethics.html">Ethics</a> &amp; <a href="../disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
-  <script defer src="/PRIVACY/assets/js/about.js"></script>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script defer src="../assets/js/about.js"></script>
+  <script src="../assets/js/main.js" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded', function () {
       if (window.initEthicsBadge) {

--- a/access-denied.html
+++ b/access-denied.html
@@ -104,14 +104,14 @@
     <p>Thanks for taking a moment to reflect. Because you chose not to accept the Ethical Access Pledge, this site is unavailable to you. That’s okay — boundaries protect everyone.</p>
     <p>If you change your mind, you can review the pledge any time and regain access by agreeing to uphold it.</p>
     <div>
-      <a class="button" href="/pledge.html">Review the Pledge</a>
+      <a class="button" href="./pledge.html">Review the Pledge</a>
     </div>
     <div class="links">
-      Learn more: <a href="/ethics.html">Ethics</a> • <a href="/disclaimer.html">Disclaimer</a>
+      Learn more: <a href="./ethics.html">Ethics</a> • <a href="./disclaimer/">Disclaimer</a>
     </div>
   </main>
   <footer>
-    <p><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+    <p><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
   </footer>
 </body>
 </html>

--- a/assets/js/disclaimer.js
+++ b/assets/js/disclaimer.js
@@ -1,0 +1,249 @@
+(function () {
+  const STORAGE_PREFIX = 'disclaimer:acknowledged:';
+
+  function computeBasePrefix(customBase) {
+    if (typeof window === 'undefined') return customBase || './';
+    if (customBase) return customBase;
+    const pathname = window.location.pathname || '';
+    const anchor = '/PRIVACY/';
+    const anchorIndex = pathname.indexOf(anchor);
+    if (anchorIndex === -1) {
+      return './';
+    }
+    const afterAnchor = pathname.slice(anchorIndex + anchor.length);
+    if (!afterAnchor) {
+      return './';
+    }
+    const segments = afterAnchor.split('/').filter(Boolean);
+    const isDirectory = pathname.endsWith('/');
+    const depth = Math.max(0, segments.length - (isDirectory ? 0 : 1));
+    if (depth === 0) {
+      return './';
+    }
+    return '../'.repeat(depth);
+  }
+
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function createModalElements(options) {
+    const overlay = document.createElement('div');
+    overlay.className = 'disclaimer-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'disclaimer-title');
+    overlay.setAttribute('aria-describedby', 'disclaimer-description');
+
+    const focusGuardStart = document.createElement('span');
+    focusGuardStart.tabIndex = 0;
+
+    const card = document.createElement('div');
+    card.className = 'disclaimer-card';
+
+    const title = document.createElement('h2');
+    title.id = 'disclaimer-title';
+    title.textContent = 'Ethics & Privacy Disclaimer';
+
+    const description = document.createElement('p');
+    description.id = 'disclaimer-description';
+    const disclaimerHref = options.disclaimerHref || './disclaimer/';
+    description.innerHTML = `Please confirm you understand and accept our <a href="${disclaimerHref}">disclaimer</a> before exploring.`;
+
+    const agreeButton = document.createElement('button');
+    agreeButton.type = 'button';
+    agreeButton.className = 'disclaimer-confirm';
+    agreeButton.textContent = 'I Understand and Agree';
+
+    const footerNote = document.createElement('p');
+    footerNote.className = 'disclaimer-version';
+    footerNote.textContent = options.version ? `Terms ${options.version}` : 'Terms';
+
+    card.append(title, description, agreeButton, footerNote);
+
+    const focusGuardEnd = document.createElement('span');
+    focusGuardEnd.tabIndex = 0;
+
+    overlay.append(focusGuardStart, card, focusGuardEnd);
+    return { overlay, agreeButton, focusGuardStart, focusGuardEnd };
+  }
+
+  function applyStyles() {
+    if (document.getElementById('disclaimer-modal-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'disclaimer-modal-styles';
+    style.textContent = `
+      .disclaimer-overlay {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(5, 8, 13, 0.88);
+        backdrop-filter: blur(6px);
+        z-index: 9999;
+        padding: 1.5rem;
+      }
+      .disclaimer-card {
+        max-width: min(480px, 100%);
+        background: #0f1724;
+        border-radius: 1rem;
+        padding: 2rem;
+        color: #f8fafc;
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+        text-align: left;
+        display: grid;
+        gap: 1.25rem;
+      }
+      .disclaimer-card h2 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+      .disclaimer-card p {
+        margin: 0;
+        line-height: 1.6;
+      }
+      .disclaimer-card a {
+        color: #4dd0e1;
+        font-weight: 600;
+      }
+      .disclaimer-confirm {
+        justify-self: start;
+        background: #4dd0e1;
+        color: #082032;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.5rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      .disclaimer-confirm:hover,
+      .disclaimer-confirm:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px rgba(77, 208, 225, 0.35);
+        outline: none;
+      }
+      .disclaimer-version {
+        font-size: 0.85rem;
+        color: rgba(248, 250, 252, 0.65);
+      }
+      body.disclaimer-locked {
+        overflow: hidden;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function trapFocus(container, guards) {
+    const focusableSelectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea',
+      'input[type="text"]',
+      'input[type="radio"]',
+      'input[type="checkbox"]',
+      'select',
+      '[tabindex]:not([tabindex="-1"])'
+    ];
+
+    function getFocusable() {
+      return Array.from(container.querySelectorAll(focusableSelectors.join(','))).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement
+      );
+    }
+
+    function loopFocus(event) {
+      const focusable = getFocusable();
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.target === guards.start && event.shiftKey) {
+        event.preventDefault();
+        last.focus();
+      } else if (event.target === guards.end && !event.shiftKey) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    guards.start.addEventListener('focus', (event) => loopFocus(event));
+    guards.end.addEventListener('focus', (event) => loopFocus(event));
+  }
+
+  function initDisclaimer(options = {}) {
+    const settings = Object.assign(
+      {
+        requireEachVisit: false,
+        version: 'v1',
+        focusTrap: false,
+        basePath: null
+      },
+      options
+    );
+
+    const storageKey = `${STORAGE_PREFIX}${settings.version}`;
+    const storage = settings.requireEachVisit ? sessionStorage : localStorage;
+
+    try {
+      if (!settings.requireEachVisit && storage.getItem(storageKey)) {
+        return;
+      }
+      if (settings.requireEachVisit && sessionStorage.getItem(storageKey)) {
+        return;
+      }
+    } catch (error) {
+      console.warn('Unable to inspect disclaimer acknowledgement', error);
+    }
+
+    ready(() => {
+      const prefix = computeBasePrefix(settings.basePath);
+      const disclaimerHref = `${prefix}disclaimer/`;
+      applyStyles();
+      const { overlay, agreeButton, focusGuardStart, focusGuardEnd } = createModalElements(
+        Object.assign({}, settings, { disclaimerHref })
+      );
+      document.body.appendChild(overlay);
+      document.body.classList.add('disclaimer-locked');
+
+      function cleanup() {
+        overlay.remove();
+        document.body.classList.remove('disclaimer-locked');
+      }
+
+      agreeButton.addEventListener('click', () => {
+        try {
+          const targetStorage = settings.requireEachVisit ? sessionStorage : localStorage;
+          targetStorage.setItem(storageKey, new Date().toISOString());
+        } catch (error) {
+          console.warn('Unable to persist disclaimer acknowledgement', error);
+        }
+        cleanup();
+      });
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          agreeButton.focus({ preventScroll: true });
+        }
+      });
+
+      focusGuardStart.addEventListener('focus', () => {
+        agreeButton.focus({ preventScroll: true });
+      });
+
+      if (settings.focusTrap) {
+        trapFocus(overlay, { start: focusGuardStart, end: focusGuardEnd });
+      }
+
+      requestAnimationFrame(() => {
+        agreeButton.focus({ preventScroll: true });
+      });
+    });
+  }
+
+  window.Disclaimer = Object.freeze({ init: initDisclaimer });
+})();

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -6,8 +6,8 @@
   <meta name="theme-color" content="#0b0f14">
   <title>Disclaimer — OSINT Secrets</title>
   <meta name="description" content="Important legal disclaimer for OSINT Secrets: educational purposes only.">
-  <link rel="canonical" href="/PRIVACY/disclaimer/">
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/disclaimer/">
+  <link rel="stylesheet" href="../assets/css/styles.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -33,18 +33,18 @@
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -53,7 +53,7 @@
   <main id="main" class="wrapper">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <ol>
-        <li><a href="/PRIVACY/">Home</a></li>
+        <li><a href="../">Home</a></li>
         <li aria-current="page">Disclaimer</li>
       </ol>
     </nav>
@@ -70,18 +70,18 @@
   <footer>
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/" aria-current="page">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/" aria-current="page">Disclaimer</a>
       </nav>
       <p>Built for privacy-first research and education.</p>
     </div>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/ethics-badge.js
+++ b/ethics-badge.js
@@ -1,10 +1,36 @@
 (function () {
+  function computeBasePrefix(customBase) {
+    if (typeof window === 'undefined') return customBase || './';
+    if (customBase) return customBase;
+    const pathname = window.location.pathname || '';
+    const anchor = '/PRIVACY/';
+    const anchorIndex = pathname.indexOf(anchor);
+    if (anchorIndex === -1) {
+      return './';
+    }
+    const afterAnchor = pathname.slice(anchorIndex + anchor.length);
+    if (!afterAnchor) {
+      return './';
+    }
+    const segments = afterAnchor.split('/').filter(Boolean);
+    const isDirectory = pathname.endsWith('/');
+    const depth = Math.max(0, segments.length - (isDirectory ? 0 : 1));
+    if (depth === 0) {
+      return './';
+    }
+    return '../'.repeat(depth);
+  }
+
   function initEthicsBadge(options = {}) {
     if (typeof document === 'undefined') return;
     if (document.querySelector('.ethics-badge-container')) return;
 
     const target = options.containerSelector ? document.querySelector(options.containerSelector) : document.body;
     if (!target) return;
+
+    const prefix = computeBasePrefix(options.basePath);
+    const ethicsHref = `${prefix}ethics.html`;
+    const disclaimerHref = `${prefix}disclaimer/`;
 
     const container = document.createElement('div');
     container.className = 'ethics-badge-container';
@@ -37,7 +63,7 @@
         <li>Use power to protect</li>
       </ul>
       <div class="ethics-links">
-        <a href="/ethics.html">Ethics Policy</a> · <a href="/disclaimer.html">Disclaimer</a>
+        <a href="${ethicsHref}">Ethics Policy</a> · <a href="${disclaimerHref}">Disclaimer</a>
       </div>
       <div class="ethics-popover-footer">
         <span>Terms v1.0</span>

--- a/ethics.html
+++ b/ethics.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Ethics</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="./">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="./" data-nav="home">Home</a>
+          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="./platform.html" data-nav="platform">Platform</a>
+          <a href="./ethics.html" data-nav="ethics">Ethics</a>
+          <a href="./why.html" data-nav="why">Why</a>
+          <a href="./about/" data-nav="about">About</a>
+          <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -93,17 +93,17 @@
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="./">Home</a>
+        <a href="./index.html#self-audit">Self-audit</a>
+        <a href="./platform.html#tools-methods">Tools and Methods</a>
+        <a href="./platform.html">Platform</a>
+        <a href="./ethics.html">Ethics</a>
+        <a href="./why.html">Why</a>
+        <a href="./about/">About</a>
+        <a href="./disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="./assets/js/main.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Home</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
-  <link rel="stylesheet" href="/ethics-badge.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
+  <link rel="stylesheet" href="./ethics-badge.css">
   <style>
     .ethics-footer-note {
       margin-top: 1rem;
@@ -26,13 +26,7 @@
       font-weight: 600;
     }
   </style>
-  <script src="/pledge.js"></script>
-  <script>
-    if (!window.hasValidPledge || !window.hasValidPledge()) {
-      window.location.href = '/pledge.html';
-    }
-  </script>
-  <script defer src="/ethics-badge.js"></script>
+  <script defer src="./ethics-badge.js"></script>
 </head>
 <body>
   <noscript>
@@ -41,18 +35,18 @@
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="./">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="./" data-nav="home">Home</a>
+          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="./platform.html" data-nav="platform">Platform</a>
+          <a href="./ethics.html" data-nav="ethics">Ethics</a>
+          <a href="./why.html" data-nav="why">Why</a>
+          <a href="./about/" data-nav="about">About</a>
+          <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -65,19 +59,31 @@
   <footer>
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="./">Home</a>
+        <a href="./index.html#self-audit">Self-audit</a>
+        <a href="./platform.html#tools-methods">Tools and Methods</a>
+        <a href="./platform.html">Platform</a>
+        <a href="./ethics.html">Ethics</a>
+        <a href="./why.html">Why</a>
+        <a href="./about/">About</a>
+        <a href="./disclaimer/">Disclaimer</a>
       </nav>
-      <p class="ethics-footer-note"><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+      <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="./assets/js/main.js" defer></script>
+  <script src="./assets/js/disclaimer.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.Disclaimer && typeof window.Disclaimer.init === 'function') {
+        window.Disclaimer.init({
+          requireEachVisit: true,
+          version: 'v1.0 (2025-10-03)',
+          focusTrap: true
+        });
+      }
+    });
+  </script>
   <script>
     window.addEventListener('DOMContentLoaded', function () {
       if (window.initEthicsBadge) {

--- a/offline.html
+++ b/offline.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Offline — Social Risk Audit</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
   <style>
     body { display: flex; align-items: center; justify-content: center; min-height: 100vh; }
     main { text-align: center; }

--- a/platform.html
+++ b/platform.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Platforms</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="./">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="./" data-nav="home">Home</a>
+          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="./platform.html" data-nav="platform">Platform</a>
+          <a href="./ethics.html" data-nav="ethics">Ethics</a>
+          <a href="./why.html" data-nav="why">Why</a>
+          <a href="./about/" data-nav="about">About</a>
+          <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -32,29 +32,29 @@
     <p class="lead">Pick a platform to see practical privacy steps.</p>
 
     <section id="tools-methods" class="grid" aria-label="Platforms">
-      <a class="tile" href="/PRIVACY/platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
-      <a class="tile" href="/PRIVACY/platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
-      <a class="tile" href="/PRIVACY/platforms/x.html" data-platform="x"><span>X</span></a>
-      <a class="tile" href="/PRIVACY/platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
-      <a class="tile" href="/PRIVACY/platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
-      <a class="tile" href="/PRIVACY/platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
+      <a class="tile" href="./platforms/facebook.html" data-platform="facebook"><span>Facebook</span></a>
+      <a class="tile" href="./platforms/instagram.html" data-platform="instagram"><span>Instagram</span></a>
+      <a class="tile" href="./platforms/x.html" data-platform="x"><span>X</span></a>
+      <a class="tile" href="./platforms/tiktok.html" data-platform="tiktok"><span>TikTok</span></a>
+      <a class="tile" href="./platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
+      <a class="tile" href="./platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
     </section>
   </main>
   <footer>
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="./">Home</a>
+        <a href="./index.html#self-audit">Self-audit</a>
+        <a href="./platform.html#tools-methods">Tools and Methods</a>
+        <a href="./platform.html">Platform</a>
+        <a href="./ethics.html">Ethics</a>
+        <a href="./why.html">Why</a>
+        <a href="./about/">About</a>
+        <a href="./disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="./assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -6,24 +6,24 @@
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — Facebook</title>
-<link href="/PRIVACY/assets/css/styles.css" rel="stylesheet"/>
+<link href="../assets/css/styles.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
 <a class="skip" href="#main">Skip to content</a>
 <div class="wrapper header-row">
-<a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+<a class="brand" href="../">Social Risk Audit</a>
 <div class="menu-container">
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
-<a data-nav="home" href="/PRIVACY/">Home</a>
-<a data-nav="self-audit" href="/PRIVACY/index.html#self-audit">Self-audit</a>
-<a data-nav="tools" href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-<a data-nav="platform" href="/PRIVACY/platform.html">Platform</a>
-<a data-nav="ethics" href="/PRIVACY/ethics.html">Ethics</a>
-<a data-nav="why" href="/PRIVACY/why.html">Why</a>
-<a data-nav="about" href="/PRIVACY/about/">About</a>
-<a data-nav="disclaimer" href="/PRIVACY/disclaimer/">Disclaimer</a>
+<a data-nav="home" href="../">Home</a>
+<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
+<a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
+<a data-nav="platform" href="../platform.html">Platform</a>
+<a data-nav="ethics" href="../ethics.html">Ethics</a>
+<a data-nav="why" href="../why.html">Why</a>
+<a data-nav="about" href="../about/">About</a>
+<a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
 </div>
@@ -32,12 +32,12 @@
 <div class="wrapper platform-wrapper">
 <div aria-hidden="true" id="page-top"></div>
 <nav aria-label="Back navigation" class="crumbs">
-<a aria-label="Back to Platforms" class="crumb back" href="/PRIVACY/platform.html">← Back</a>
+<a aria-label="Back to Platforms" class="crumb back" href="../platform.html">← Back</a>
 </nav>
 <nav aria-label="Breadcrumb" class="breadcrumb">
 <ol>
-<li><a href="/PRIVACY/">Home</a></li>
-<li><a href="/PRIVACY/platform.html">Platforms</a></li>
+<li><a href="../">Home</a></li>
+<li><a href="../platform.html">Platforms</a></li>
 <li aria-current="page">Facebook</li>
 </ol>
 </nav>
@@ -3458,18 +3458,18 @@
 <div class="wrapper footer-layout">
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
-<a href="/PRIVACY/">Home</a>
-<a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-<a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-<a href="/PRIVACY/platform.html">Platform</a>
-<a href="/PRIVACY/ethics.html">Ethics</a>
-<a href="/PRIVACY/why.html">Why</a>
-<a href="/PRIVACY/about/">About</a>
-<a href="/PRIVACY/disclaimer/">Disclaimer</a>
+<a href="../">Home</a>
+<a href="../index.html#self-audit">Self-audit</a>
+<a href="../platform.html#tools-methods">Tools and Methods</a>
+<a href="../platform.html">Platform</a>
+<a href="../ethics.html">Ethics</a>
+<a href="../why.html">Why</a>
+<a href="../about/">About</a>
+<a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
 </footer>
-<script defer="" src="/PRIVACY/assets/js/facebook.js"></script>
-<script defer="" src="/PRIVACY/assets/js/main.js"></script>
+<script defer="" src="../assets/js/facebook.js"></script>
+<script defer="" src="../assets/js/main.js"></script>
 </body>
 </html>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Instagram</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -30,7 +30,7 @@
 
   <main id="main" class="wrapper">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+      <a class="crumb back" href="../platform.html" aria-label="Back to Platforms">← Back</a>
     </nav>
 
     <h1>Instagram</h1>
@@ -54,18 +54,18 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
 
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Telegram</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -30,7 +30,7 @@
 
   <main id="main" class="wrapper">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+      <a class="crumb back" href="../platform.html" aria-label="Back to Platforms">← Back</a>
     </nav>
 
     <h1>Telegram</h1>
@@ -54,18 +54,18 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
 
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — TikTok</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -30,7 +30,7 @@
 
   <main id="main" class="wrapper">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+      <a class="crumb back" href="../platform.html" aria-label="Back to Platforms">← Back</a>
     </nav>
 
     <h1>TikTok</h1>
@@ -54,18 +54,18 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
 
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — WhatsApp</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -30,7 +30,7 @@
 
   <main id="main" class="wrapper">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+      <a class="crumb back" href="../platform.html" aria-label="Back to Platforms">← Back</a>
     </nav>
 
     <h1>WhatsApp</h1>
@@ -54,18 +54,18 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
 
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — X</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="../">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -30,7 +30,7 @@
 
   <main id="main" class="wrapper">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a class="crumb back" href="/PRIVACY/platform.html" aria-label="Back to Platforms">← Back</a>
+      <a class="crumb back" href="../platform.html" aria-label="Back to Platforms">← Back</a>
     </nav>
 
     <h1>X</h1>
@@ -54,18 +54,18 @@
     <div class="wrapper footer-layout">
       <p>Utility-first build — no trackers.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="../disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
 
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/pledge.html
+++ b/pledge.html
@@ -7,10 +7,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/pledge.css">
-  <link rel="stylesheet" href="/ethics-badge.css">
-  <script src="/pledge.js"></script>
-  <script defer src="/ethics-badge.js"></script>
+  <link rel="stylesheet" href="./pledge.css">
+  <link rel="stylesheet" href="./ethics-badge.css">
+  <script src="./pledge.js"></script>
+  <script defer src="./ethics-badge.js"></script>
 </head>
 <body data-pledge-page>
   <noscript>
@@ -24,7 +24,7 @@
       </header>
 
       <div class="pane" data-step="intro" aria-labelledby="pane-title" aria-describedby="intro-description">
-        <div id="intro-description" class="intro-text">Explore responsibly. Learn why our ethics matter on the <a href="/ethics.html">Ethics page</a> and review the <a href="/disclaimer.html">Disclaimer</a> before proceeding.</div>
+        <div id="intro-description" class="intro-text">Explore responsibly. Learn why our ethics matter on the <a href="./ethics.html">Ethics page</a> and review the <a href="./disclaimer/">Disclaimer</a> before proceeding.</div>
         <article class="pledge-scroll-card" aria-label="Pledge text" tabindex="0" data-scrollable>
           <div class="scroll-progress" aria-hidden="true">
             <div class="scroll-progress-bar" style="width:0%"></div>
@@ -41,7 +41,7 @@
           <button class="btn primary" data-action="to-checkboxes" disabled>
             Continue
           </button>
-          <a href="/access-denied.html" class="link-negative">No, I don’t agree</a>
+          <a href="./access-denied.html" class="link-negative">No, I don’t agree</a>
         </div>
       </div>
 
@@ -104,7 +104,7 @@
     </section>
   </main>
   <footer class="site-footer">
-    <p><a href="/ethics.html">Ethics</a> &amp; <a href="/disclaimer.html">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+    <p><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
   </footer>
 </body>
 </html>

--- a/pledge.js
+++ b/pledge.js
@@ -185,7 +185,7 @@
 
     function completeFlow() {
       persistToken();
-      window.location.href = '/index.html';
+      window.location.href = './index.html';
     }
 
     if (continueButton) {

--- a/why.html
+++ b/why.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Why Privacy</title>
-  <link rel="stylesheet" href="/PRIVACY/assets/css/styles.css">
+  <link rel="stylesheet" href="./assets/css/styles.css">
 </head>
 <body>
   <header>
     <a class="skip" href="#main">Skip to content</a>
     <div class="wrapper header-row">
-      <a class="brand" href="/PRIVACY/">Social Risk Audit</a>
+      <a class="brand" href="./">Social Risk Audit</a>
       <div class="menu-container">
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
-          <a href="/PRIVACY/" data-nav="home">Home</a>
-          <a href="/PRIVACY/index.html#self-audit" data-nav="self-audit">Self-audit</a>
-          <a href="/PRIVACY/platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
-          <a href="/PRIVACY/platform.html" data-nav="platform">Platform</a>
-          <a href="/PRIVACY/ethics.html" data-nav="ethics">Ethics</a>
-          <a href="/PRIVACY/why.html" data-nav="why">Why</a>
-          <a href="/PRIVACY/about/" data-nav="about">About</a>
-          <a href="/PRIVACY/disclaimer/" data-nav="disclaimer">Disclaimer</a>
+          <a href="./" data-nav="home">Home</a>
+          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="./platform.html" data-nav="platform">Platform</a>
+          <a href="./ethics.html" data-nav="ethics">Ethics</a>
+          <a href="./why.html" data-nav="why">Why</a>
+          <a href="./about/" data-nav="about">About</a>
+          <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
     </div>
@@ -57,17 +57,17 @@
     <div class="wrapper footer-layout">
       <p>Last updated: September 2023. Built for fast, private browsing.</p>
       <nav class="footer-links" aria-label="Footer">
-        <a href="/PRIVACY/">Home</a>
-        <a href="/PRIVACY/index.html#self-audit">Self-audit</a>
-        <a href="/PRIVACY/platform.html#tools-methods">Tools and Methods</a>
-        <a href="/PRIVACY/platform.html">Platform</a>
-        <a href="/PRIVACY/ethics.html">Ethics</a>
-        <a href="/PRIVACY/why.html">Why</a>
-        <a href="/PRIVACY/about/">About</a>
-        <a href="/PRIVACY/disclaimer/">Disclaimer</a>
+        <a href="./">Home</a>
+        <a href="./index.html#self-audit">Self-audit</a>
+        <a href="./platform.html#tools-methods">Tools and Methods</a>
+        <a href="./platform.html">Platform</a>
+        <a href="./ethics.html">Ethics</a>
+        <a href="./why.html">Why</a>
+        <a href="./about/">About</a>
+        <a href="./disclaimer/">Disclaimer</a>
       </nav>
     </div>
   </footer>
-  <script src="/PRIVACY/assets/js/main.js" defer></script>
+  <script src="./assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the pledge redirect scripts and wire index.html to the existing disclaimer modal
- add a reusable disclaimer.js overlay and convert navigation/footer URLs to relative paths across the site
- update the ethics badge and pledge redirect logic to respect relative path resolution

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df6449b728832388997855b27cc8ba