### PR TITLE
Enforce ethics pledge gate across public pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A stripped-back, utility-first privacy guide for the Platform checklist with eth
 ├── why.html                # Why privacy matters
 ├── assets/
 │   ├── css/styles.css      # Single utility-first stylesheet
-│   └── js/main.js          # Progressive enhancement for navigation state
+│   └── js/
+│       ├── main.js         # Progressive enhancement for navigation state
+│       └── pledge-gate.js  # Shared pledge enforcement redirect
 ├── manifest.json           # Minimal PWA metadata (dormant)
 ├── sw.js                   # Offline cache shell (not registered by default)
 └── offline.html            # Lightweight offline notice
@@ -41,6 +43,10 @@ Then open [http://localhost:8000/index.html](http://localhost:8000/index.html). 
 - System font stack, high-contrast palette, and consistent focus outlines.
 - Skip link and semantic landmarks on every page.
 - No analytics, no external fonts, no third-party network requests.
+
+## Ethics pledge gate
+
+All public-facing pages load a shared script that checks for a valid pledge token (`ETHICS_PLEDGE_TOKEN`) and matching `TERMS_VERSION` entry in `sessionStorage`. If a visitor has not completed the pledge—or an older pledge version is detected—they are redirected to `./pledge.html` on page load to review and accept the current terms before continuing.
 
 ## Deployment
 

--- a/about/index.html
+++ b/about/index.html
@@ -150,6 +150,7 @@
       <p class="ethics-footer-note"><a href="../ethics.html">Ethics</a> &amp; <a href="../disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script defer src="../assets/js/about.js"></script>
   <script src="../assets/js/main.js" defer></script>
   <script>

--- a/assets/js/pledge-gate.js
+++ b/assets/js/pledge-gate.js
@@ -1,0 +1,120 @@
+(function () {
+  const TOKEN_KEY = 'ETHICS_PLEDGE_TOKEN';
+  const TERMS_VERSION_KEY = 'TERMS_VERSION';
+  const TERMS_VERSION = 'v1.0 (2025-10-03)';
+  const EXEMPT_FILES = new Set(['pledge.html', 'access-denied.html']);
+
+  function parseToken(raw) {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn('Invalid pledge token payload', error);
+      return null;
+    }
+  }
+
+  function storageHasValidPledge() {
+    if (typeof window === 'undefined') return false;
+    try {
+      const stored = parseToken(sessionStorage.getItem(TOKEN_KEY));
+      if (!stored || typeof stored.token !== 'string' || stored.token.length === 0) {
+        return false;
+      }
+      if (stored.version !== TERMS_VERSION) {
+        return false;
+      }
+      const storedVersion = sessionStorage.getItem(TERMS_VERSION_KEY);
+      if (storedVersion !== TERMS_VERSION) {
+        return false;
+      }
+      return true;
+    } catch (error) {
+      console.warn('Unable to read pledge token', error);
+      return false;
+    }
+  }
+
+  function hasValidPledge() {
+    if (typeof window === 'undefined') return false;
+    if (window.ETHICS_PLEDGE && typeof window.ETHICS_PLEDGE.hasValidPledge === 'function') {
+      try {
+        return Boolean(window.ETHICS_PLEDGE.hasValidPledge());
+      } catch (error) {
+        console.warn('Error invoking ETHICS_PLEDGE.hasValidPledge', error);
+      }
+    }
+    if (typeof window.hasValidPledge === 'function') {
+      try {
+        return Boolean(window.hasValidPledge());
+      } catch (error) {
+        console.warn('Error invoking hasValidPledge', error);
+      }
+    }
+    return storageHasValidPledge();
+  }
+
+  function shouldSkipGate() {
+    if (typeof window === 'undefined') return true;
+    const path = window.location.pathname;
+    const pathWithoutTrailingSlash = path.replace(/\/+$/, '/');
+    const segments = pathWithoutTrailingSlash.split('/').filter(Boolean);
+    const lastSegment = segments.length ? segments[segments.length - 1] : '';
+    if (EXEMPT_FILES.has(lastSegment)) {
+      return true;
+    }
+    if (!lastSegment && segments.length) {
+      const parentSegment = segments[segments.length - 1];
+      if (EXEMPT_FILES.has(`${parentSegment}.html`)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function computeRedirectPath() {
+    if (typeof window === 'undefined') return './pledge.html';
+    let baseHref = window.location.href;
+    if (typeof document !== 'undefined') {
+      const brand = document.querySelector('.brand[href]');
+      if (brand) {
+        const href = brand.getAttribute('href') || './';
+        try {
+          baseHref = new URL(href, window.location.href).href;
+        } catch (error) {
+          console.warn('Unable to resolve brand href for pledge redirect', error);
+        }
+      }
+    }
+    let pledgeUrl;
+    try {
+      pledgeUrl = new URL('./pledge.html', baseHref);
+    } catch (error) {
+      console.warn('Unable to resolve pledge redirect URL', error);
+      return './pledge.html';
+    }
+    if (pledgeUrl.origin === window.location.origin) {
+      return pledgeUrl.pathname + pledgeUrl.search + pledgeUrl.hash;
+    }
+    return pledgeUrl.href;
+  }
+
+  function handleDOMContentLoaded() {
+    if (shouldSkipGate()) return;
+    if (hasValidPledge()) return;
+    const redirectPath = computeRedirectPath();
+    try {
+      window.location.replace(redirectPath);
+    } catch (error) {
+      window.location.href = redirectPath;
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', handleDOMContentLoaded, { once: true });
+    } else {
+      handleDOMContentLoaded();
+    }
+  }
+})();

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -82,6 +82,7 @@
       <p>Built for privacy-first research and education.</p>
     </div>
   </footer>
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/ethics.html
+++ b/ethics.html
@@ -104,6 +104,7 @@
       </nav>
     </div>
   </footer>
+  <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
+  <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
   <script src="./assets/js/disclaimer.js" defer></script>
   <script>

--- a/platform.html
+++ b/platform.html
@@ -55,6 +55,7 @@
       </nav>
     </div>
   </footer>
+  <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -3469,6 +3469,7 @@
 </nav>
 </div>
 </footer>
+<script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/facebook.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
 </body>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -66,6 +66,7 @@
     </div>
   </footer>
 
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -66,6 +66,7 @@
     </div>
   </footer>
 
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -66,6 +66,7 @@
     </div>
   </footer>
 
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -66,6 +66,7 @@
     </div>
   </footer>
 
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -66,6 +66,7 @@
     </div>
   </footer>
 
+  <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
 </body>
 </html>

--- a/pledge.js
+++ b/pledge.js
@@ -1,6 +1,7 @@
 (function () {
   const TERMS_VERSION = 'v1.0 (2025-10-03)';
   const TOKEN_KEY = 'ETHICS_PLEDGE_TOKEN';
+  const TERMS_VERSION_KEY = 'TERMS_VERSION';
   const CONFIRM_PHRASE = 'I AGREE TO USE THIS ETHICALLY';
 
   function parseStoredToken(raw) {
@@ -17,7 +18,14 @@
     if (typeof window === 'undefined') return false;
     try {
       const stored = parseStoredToken(sessionStorage.getItem(TOKEN_KEY));
-      return Boolean(stored && stored.version === TERMS_VERSION && typeof stored.token === 'string' && stored.token.length > 0);
+      if (!stored || stored.version !== TERMS_VERSION) {
+        return false;
+      }
+      const storedVersion = sessionStorage.getItem(TERMS_VERSION_KEY);
+      if (storedVersion !== TERMS_VERSION) {
+        return false;
+      }
+      return Boolean(typeof stored.token === 'string' && stored.token.length > 0);
     } catch (error) {
       console.warn('Unable to read pledge token', error);
       return false;
@@ -26,7 +34,7 @@
 
   if (typeof window !== 'undefined') {
     window.hasValidPledge = hasValidPledge;
-    window.ETHICS_PLEDGE = Object.freeze({ TERMS_VERSION, TOKEN_KEY, hasValidPledge });
+    window.ETHICS_PLEDGE = Object.freeze({ TERMS_VERSION, TOKEN_KEY, TERMS_VERSION_KEY, hasValidPledge });
   }
 
   function ready(callback) {
@@ -178,6 +186,7 @@
       const payload = { token: generateToken(), version: TERMS_VERSION, createdAt: new Date().toISOString() };
       try {
         sessionStorage.setItem(TOKEN_KEY, JSON.stringify(payload));
+        sessionStorage.setItem(TERMS_VERSION_KEY, TERMS_VERSION);
       } catch (error) {
         console.warn('Unable to store pledge token', error);
       }

--- a/why.html
+++ b/why.html
@@ -68,6 +68,7 @@
       </nav>
     </div>
   </footer>
+  <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared pledge gate script that validates the session pledge token/version and redirects visitors who have not accepted the terms
- store the current terms version alongside the pledge token and expose it for reuse by the gate
- include the gate script on every public page and document the enforced redirect in the README

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68df6a906e988323851a296e573f45a1