### PR TITLE
Store pledge redirect destination and restore after completion

### DIFF
--- a/assets/js/pledge-gate.js
+++ b/assets/js/pledge-gate.js
@@ -3,6 +3,7 @@
   const TERMS_VERSION_KEY = 'TERMS_VERSION';
   const TERMS_VERSION = 'v1.0 (2025-10-03)';
   const EXEMPT_FILES = new Set(['pledge.html', 'access-denied.html']);
+  const REDIRECT_KEY = 'ETHICS_PLEDGE_REDIRECT_URL';
 
   function parseToken(raw) {
     if (!raw) return null;
@@ -104,6 +105,11 @@
     if (hasValidPledge()) return;
     const redirectPath = computeRedirectPath();
     try {
+      try {
+        sessionStorage.setItem(REDIRECT_KEY, window.location.href);
+      } catch (storageError) {
+        console.warn('Unable to store requested URL for pledge redirect', storageError);
+      }
       window.location.replace(redirectPath);
     } catch (error) {
       window.location.href = redirectPath;

--- a/pledge.js
+++ b/pledge.js
@@ -3,6 +3,7 @@
   const TOKEN_KEY = 'ETHICS_PLEDGE_TOKEN';
   const TERMS_VERSION_KEY = 'TERMS_VERSION';
   const CONFIRM_PHRASE = 'I AGREE TO USE THIS ETHICALLY';
+  const REDIRECT_KEY = 'ETHICS_PLEDGE_REDIRECT_URL';
 
   function parseStoredToken(raw) {
     if (!raw) return null;
@@ -192,8 +193,26 @@
       }
     }
 
+    function consumeStoredRedirectUrl() {
+      try {
+        const stored = sessionStorage.getItem(REDIRECT_KEY);
+        if (stored) {
+          sessionStorage.removeItem(REDIRECT_KEY);
+        }
+        return stored;
+      } catch (error) {
+        console.warn('Unable to read stored redirect URL', error);
+        return null;
+      }
+    }
+
     function completeFlow() {
       persistToken();
+      const redirectUrl = consumeStoredRedirectUrl();
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+        return;
+      }
       window.location.href = './index.html';
     }
 


### PR DESCRIPTION
## Summary
- store the requested URL before gatekeeping visitors on pledge.html
- redirect successful pledges back to the original location and clear the stored data

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df6e031a748323b23a9a442391f078