### PR TITLE
Add mobile single-column layout for platform grid

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -46,6 +46,7 @@ footer .wrapper{padding-top:var(--space);padding-bottom:var(--space);font-size:0
 :root[data-rm='on'] *,[data-rm='on'] *{transition:none!important;animation:none!important;}
 .lead{ color:var(--muted); margin-bottom: var(--space); }
 .grid{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: var(--space); }
+@media (max-width: 599px){ .grid{ grid-template-columns: 1fr; } }
 @media (min-width: 720px){ .grid{ grid-template-columns: repeat(3, minmax(0,1fr)); } }
 .tile{ display:flex; align-items:center; justify-content:center; min-height: 100px; border:1px solid var(--border); border-radius: var(--radius); background: var(--card, #0f141b); color: var(--text); text-decoration:none; font-weight:600; }
 .tile:hover{ background:#0f1b20; }


### PR DESCRIPTION
## Summary
- add a mobile breakpoint that stacks platform grid tiles into a single column while keeping existing tablet/desktop layouts

## Testing
- previewed platform.html in a 375px-wide viewport

------
https://chatgpt.com/codex/tasks/task_e_68df72ceb57c832382b8fc5ef94c1266