### PR TITLE
Register service worker on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ A stripped-back, utility-first privacy guide for the Platform checklist with eth
 ├── assets/
 │   ├── css/styles.css      # Single utility-first stylesheet
 │   └── js/
-│       ├── main.js         # Progressive enhancement for navigation state
+│       ├── main.js         # Progressive enhancement for navigation state + SW registration
 │       └── pledge-gate.js  # Shared pledge enforcement redirect
 ├── manifest.json           # Minimal PWA metadata (dormant)
-├── sw.js                   # Offline cache shell (not registered by default)
+├── sw.js                   # Offline cache shell (auto-registered)
 └── offline.html            # Lightweight offline notice
 ```
 
@@ -36,7 +36,13 @@ Serve the repo root with any static server to preview:
 python -m http.server 8000
 ```
 
-Then open [http://localhost:8000/index.html](http://localhost:8000/index.html). The service worker will only activate if you register it manually during testing.
+Then open [http://localhost:8000/index.html](http://localhost:8000/index.html). The service worker registers automatically on load.
+
+To verify the offline shell:
+
+1. Visit the site in a browser and allow the initial load to complete (which installs the worker).
+2. Stop the local server or toggle the browser's network inspector to “offline”.
+3. Reload any page—navigation should fall back to `offline.html`.
 
 ## Accessibility & privacy
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,37 @@
 (function(){
+  function computeBasePrefix(customBase) {
+    if (typeof window === 'undefined') return customBase || './';
+    if (customBase) return customBase;
+    const pathname = window.location.pathname || '';
+    const anchor = '/PRIVACY/';
+    const anchorIndex = pathname.indexOf(anchor);
+    if (anchorIndex === -1) {
+      return './';
+    }
+    const afterAnchor = pathname.slice(anchorIndex + anchor.length);
+    if (!afterAnchor) {
+      return './';
+    }
+    const segments = afterAnchor.split('/').filter(Boolean);
+    const isDirectory = pathname.endsWith('/');
+    const depth = Math.max(0, segments.length - (isDirectory ? 0 : 1));
+    if (depth === 0) {
+      return './';
+    }
+    return '../'.repeat(depth);
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('load', () => {
+      if (!('serviceWorker' in navigator)) return;
+      const prefix = computeBasePrefix();
+      const workerUrl = `${prefix}sw.js`;
+      navigator.serviceWorker.register(workerUrl).catch((error) => {
+        console.error('Service worker registration failed:', error);
+      });
+    });
+  }
+
   const btn = document.querySelector('.menu-toggle');
   const menu = document.getElementById('site-menu');
   if (!btn || !menu) return;


### PR DESCRIPTION
## Summary
- register the service worker on window load with base-aware URLs so nested paths work
- catch registration failures to avoid breaking the UI
- document the automatic registration flow and how to verify the offline shell

## Testing
- browser_container.run_playwright_script (verify service worker registration and offline fallback)

------
https://chatgpt.com/codex/tasks/task_e_68df72cc4ef48323b07c0d588faa9d20