### PR TITLE
Enhance home self-audit with persistent checklists

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -31,6 +31,26 @@ h1{font-size:clamp(28px,6vw,48px);line-height:1.15;margin:0 0 var(--space) 0;}
 .button-group{display:flex;flex-direction:column;gap:12px;}
 @media (min-width:600px){.button-group{flex-direction:row;}}
 .card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:var(--space);}
+.audit-grid{display:grid;gap:calc(var(--space)*1.2);}
+@media (min-width:640px){.audit-grid{grid-template-columns:repeat(auto-fit,minmax(280px,1fr));}}
+.audit-card{display:flex;flex-direction:column;gap:var(--space);}
+.card-header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space);}
+.card-header h2{margin:0;}
+.card-subhead{margin:4px 0 0;color:var(--muted);font-size:0.95rem;}
+.progress-chip{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:4px 12px;border-radius:999px;border:1px solid var(--border);background:#0f1a22;color:var(--muted);font-size:0.85rem;font-weight:600;white-space:nowrap;}
+.progress-chip.is-complete{background:rgba(0,230,255,0.15);border-color:rgba(0,230,255,0.45);color:var(--accent);}
+.audit-details summary{font-size:1rem;}
+.audit-details[open]>summary{margin-bottom:10px;}
+.checklist{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px;}
+.checklist-item{display:flex;align-items:flex-start;gap:12px;padding:12px 14px;border-radius:12px;border:1px solid var(--border);background:#0e151b;transition:border-color 0.2s ease,background 0.2s ease;}
+.checklist-item input{flex:none;width:20px;height:20px;margin-top:2px;border-radius:6px;border:1px solid var(--border);background:#0b0f14;accent-color:#00d0ea;}
+.checklist-item input:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.checklist-item span{flex:1;color:var(--text);font-size:0.95rem;}
+.checklist-item input:checked+span{color:var(--accent);}
+.audit-guides{display:flex;flex-wrap:wrap;gap:10px;margin-top:auto;}
+.audit-guides .button{flex:1 1 auto;text-align:center;}
+.audit-card[data-complete="true"]{border-color:rgba(0,230,255,0.45);box-shadow:0 0 0 1px rgba(0,230,255,0.2);}
+.audit-card[data-complete="true"] .card-subhead{color:var(--accent);}
 section+section{margin-top:calc(var(--space)*1.5);}
 .notice{border-left:4px solid var(--accent);padding:var(--space);border-radius:var(--radius);background:#0e151b;color:var(--muted);margin-bottom:calc(var(--space)*1.5);}
 .details-list details{background:#0e151b;border:1px solid var(--border);border-radius:var(--radius);padding:var(--space);} 

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,95 @@
+(function () {
+  const STORAGE_KEY = 'sra-home-checklists';
+
+  const readState = () => {
+    if (!('localStorage' in window)) {
+      return {};
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (error) {
+      return {};
+    }
+  };
+
+  const writeState = (state) => {
+    if (!('localStorage' in window)) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      // Ignore persistence errors (e.g., private mode).
+    }
+  };
+
+  const updateCardProgress = (card, checkboxes) => {
+    const total = checkboxes.length;
+    const completed = checkboxes.filter((input) => input.checked).length;
+    const progressChip = card.querySelector('.progress-chip');
+    const title = card.querySelector('h2');
+    const safeTitle = title ? title.textContent.trim() : 'Checklist';
+    const progressLabel = `${completed}/${total} complete`;
+
+    if (progressChip) {
+      if (!progressChip.id) {
+        progressChip.id = `${card.dataset.checklistId || 'checklist'}-progress`;
+      }
+
+      progressChip.textContent = progressLabel;
+      progressChip.classList.toggle('is-complete', total > 0 && completed === total);
+      progressChip.setAttribute(
+        'aria-label',
+        `${safeTitle} progress: ${completed} of ${total} tasks complete`
+      );
+      card.setAttribute('aria-describedby', progressChip.id);
+    }
+
+    card.dataset.complete = total > 0 && completed === total ? 'true' : 'false';
+    card.setAttribute('data-progress-count', completed);
+    card.setAttribute('data-progress-total', total);
+    card.setAttribute('aria-roledescription', 'Checklist');
+    card.setAttribute(
+      'aria-label',
+      `${safeTitle} checklist with ${total} tasks, ${completed} complete`
+    );
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const cards = Array.from(document.querySelectorAll('[data-checklist-id]'));
+    if (!cards.length) {
+      return;
+    }
+
+    const state = readState();
+
+    cards.forEach((card) => {
+      const checklistId = card.dataset.checklistId;
+      const checkboxes = Array.from(
+        card.querySelectorAll('input[type="checkbox"][data-checklist-item]')
+      );
+      const storedValues = Array.isArray(state[checklistId]) ? state[checklistId] : [];
+
+      checkboxes.forEach((input) => {
+        if (storedValues.includes(input.value)) {
+          input.checked = true;
+        }
+
+        input.addEventListener('change', () => {
+          const selected = checkboxes
+            .filter((item) => item.checked)
+            .map((item) => item.value);
+
+          state[checklistId] = selected;
+          writeState(state);
+          updateCardProgress(card, checkboxes);
+        });
+      });
+
+      updateCardProgress(card, checkboxes);
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -55,6 +55,129 @@
   <main id="main">
     <section id="self-audit" class="wrapper">
       <h1>Privacy is not something that is given to you — be the master of your privacy.</h1>
+      <p class="lead">Use this self-audit to track operational risks, then dive into the platform guides for concrete fixes.</p>
+
+      <div class="audit-grid">
+        <article class="card audit-card" role="group" aria-labelledby="audit-account-security" data-checklist-id="account-security">
+          <header class="card-header">
+            <div>
+              <h2 id="audit-account-security">Account security</h2>
+              <p class="card-subhead">Protect privileged access and reduce account takeover risk.</p>
+            </div>
+            <span class="progress-chip" role="status" aria-live="polite">0/3 complete</span>
+          </header>
+          <details class="audit-details" open>
+            <summary>Quick win checklist</summary>
+            <ul class="checklist" role="list">
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="mfa" data-checklist-item>
+                  <span>Require multi-factor authentication for every administrative role.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="access-review" data-checklist-item>
+                  <span>Review staff and vendor access every quarter and remove stale accounts.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="password-manager" data-checklist-item>
+                  <span>Adopt a password manager with shared vaults for newsroom credentials.</span>
+                </label>
+              </li>
+            </ul>
+          </details>
+          <nav class="audit-guides" aria-label="Account security resources">
+            <a class="button" href="./platforms/facebook.html">Facebook guide</a>
+            <a class="button" href="./platforms/instagram.html">Instagram guide</a>
+            <a class="button" href="./platforms/telegram.html">Telegram guide</a>
+          </nav>
+        </article>
+
+        <article class="card audit-card" role="group" aria-labelledby="audit-data-minimization" data-checklist-id="data-minimization">
+          <header class="card-header">
+            <div>
+              <h2 id="audit-data-minimization">Data minimization</h2>
+              <p class="card-subhead">Collect only what you need and protect the information you keep.</p>
+            </div>
+            <span class="progress-chip" role="status" aria-live="polite">0/3 complete</span>
+          </header>
+          <details class="audit-details" open>
+            <summary>Quick win checklist</summary>
+            <ul class="checklist" role="list">
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="inventory" data-checklist-item>
+                  <span>Maintain a live inventory of the personal data you store across systems.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="retention" data-checklist-item>
+                  <span>Set retention limits for sources, audience analytics, and off-platform exports.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="sharing" data-checklist-item>
+                  <span>Document who you share sensitive data with and why access is necessary.</span>
+                </label>
+              </li>
+            </ul>
+          </details>
+          <nav class="audit-guides" aria-label="Data minimization resources">
+            <a class="button" href="./platforms/tiktok.html">TikTok guide</a>
+            <a class="button" href="./platforms/whatsapp.html">WhatsApp guide</a>
+            <a class="button" href="./platforms/x.html">X guide</a>
+          </nav>
+        </article>
+
+        <article class="card audit-card" role="group" aria-labelledby="audit-crisis-response" data-checklist-id="crisis-response">
+          <header class="card-header">
+            <div>
+              <h2 id="audit-crisis-response">Crisis response</h2>
+              <p class="card-subhead">Prepare for harassment, takedowns, and emergency incidents.</p>
+            </div>
+            <span class="progress-chip" role="status" aria-live="polite">0/4 complete</span>
+          </header>
+          <details class="audit-details" open>
+            <summary>Quick win checklist</summary>
+            <ul class="checklist" role="list">
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="playbook" data-checklist-item>
+                  <span>Publish a crisis playbook with decision-makers and escalation contacts.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="reporting" data-checklist-item>
+                  <span>Train staff to report impersonation, hacking, and doxxing attempts quickly.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="evidence" data-checklist-item>
+                  <span>Collect evidence safely and store takedown documentation in a secure space.</span>
+                </label>
+              </li>
+              <li>
+                <label class="checklist-item">
+                  <input type="checkbox" value="support" data-checklist-item>
+                  <span>Offer targeted support for staff experiencing harassment or trauma.</span>
+                </label>
+              </li>
+            </ul>
+          </details>
+          <nav class="audit-guides" aria-label="Crisis response resources">
+            <a class="button" href="./platforms/facebook.html">Facebook safety steps</a>
+            <a class="button" href="./platforms/telegram.html">Telegram reporting guide</a>
+            <a class="button" href="./platforms/whatsapp.html">WhatsApp backup guide</a>
+          </nav>
+        </article>
+      </div>
     </section>
   </main>
   <footer>
@@ -72,6 +195,7 @@
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
     </div>
   </footer>
+  <script src="./assets/js/home.js" defer></script>
   <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
   <script src="./assets/js/disclaimer.js" defer></script>


### PR DESCRIPTION
## Summary
- expand the home self-audit section into three actionable checklist cards linked to platform guidance
- add layout utilities for audit cards, progress chips, and checklists to match the design system
- introduce a home-only script that saves checklist progress to localStorage and updates accessibility metadata

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df792e300c832380c16dcea79814dd