### PR TITLE
Add contact page and update navigation links

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -58,6 +58,7 @@
           <a href="../ethics.html" data-nav="ethics">Ethics</a>
           <a href="../why.html" data-nav="why">Why</a>
           <a href="./" data-nav="about">About</a>
+          <a href="../contact/" data-nav="contact">Contact</a>
           <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -144,6 +145,7 @@
         <a href="../ethics.html">Ethics</a>
         <a href="../why.html">Why</a>
         <a href="./" aria-current="page">About</a>
+        <a href="../contact/">Contact</a>
         <a href="../disclaimer/">Disclaimer</a>
       </nav>
       <p>© 2025 OSINT Secrets</p>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -90,6 +90,7 @@
     else if (normalized === '/ethics.html') current = 'ethics';
     else if (normalized === '/why.html') current = 'why';
     else if (normalized === '/about/' || normalized === '/about') current = 'about';
+    else if (normalized === '/contact/' || normalized === '/contact') current = 'contact';
     else if (normalized === '/disclaimer/' || normalized === '/disclaimer') current = 'disclaimer';
   }
   if (current) document.querySelector(`[data-nav="${current}"]`)?.setAttribute('aria-current','page');

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Contact — Social Risk Audit</title>
+  <meta name="description" content="Reach the Social Risk Audit team for general questions, urgent safety escalations, or encrypted follow-ups.">
+  <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/contact/">
+  <meta property="og:title" content="Contact — Social Risk Audit">
+  <meta property="og:description" content="Reach the Social Risk Audit team for general questions, urgent safety escalations, or encrypted follow-ups.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/PRIVACY/contact/">
+  <meta property="og:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
+  <meta property="og:site_name" content="OSINT Secrets">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Contact — Social Risk Audit">
+  <meta name="twitter:description" content="Reach the Social Risk Audit team for general questions, urgent safety escalations, or encrypted follow-ups.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/PRIVACY/icons-s/1.png">
+  <link rel="stylesheet" href="../assets/css/styles.css">
+  <link rel="stylesheet" href="../ethics-badge.css">
+  <style>
+    .contact-intro {
+      margin: 0 auto 2.5rem;
+      max-width: 60ch;
+      text-align: center;
+    }
+    .contact-grid {
+      display: grid;
+      gap: 2rem;
+      margin: 0 auto;
+      max-width: 70rem;
+    }
+    .contact-card {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 0.75rem;
+      padding: 1.75rem;
+      box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.15);
+    }
+    .contact-card h2 {
+      margin-top: 0;
+    }
+    .contact-card ul {
+      padding-left: 1.25rem;
+    }
+    .contact-meta {
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.8);
+    }
+    .contact-meta code {
+      font-size: 0.9rem;
+    }
+    .urgent-note {
+      background: rgba(214, 64, 69, 0.1);
+      border-left: 4px solid #d64045;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      margin-top: 1rem;
+    }
+    @media (min-width: 60rem) {
+      .contact-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .contact-card:last-child {
+        grid-column: 1 / -1;
+      }
+    }
+    .ethics-footer-note {
+      margin-top: 0.75rem;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.7);
+    }
+    .ethics-footer-note a {
+      color: inherit;
+      font-weight: 600;
+    }
+    .noscript-warning {
+      margin: 0;
+      padding: 0.75rem 1rem;
+      text-align: center;
+      background: #d64045;
+      color: #fff;
+      font-weight: 600;
+    }
+  </style>
+  <script defer src="../ethics-badge.js"></script>
+</head>
+<body>
+  <noscript>
+    <div class="noscript-warning">This site requires JavaScript to enforce the Ethics Pledge.</div>
+  </noscript>
+  <header>
+    <a class="skip" href="#main">Skip to content</a>
+    <div class="wrapper header-row">
+      <a class="brand" href="../">Social Risk Audit</a>
+      <div class="menu-container">
+        <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
+        <nav id="site-menu" class="menu" hidden aria-label="Primary">
+          <a href="../" data-nav="home">Home</a>
+          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
+          <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
+          <a href="../platform.html" data-nav="platform">Platform</a>
+          <a href="../ethics.html" data-nav="ethics">Ethics</a>
+          <a href="../why.html" data-nav="why">Why</a>
+          <a href="../about/" data-nav="about">About</a>
+          <a href="./" data-nav="contact">Contact</a>
+          <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
+        </nav>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="wrapper prose" style="padding-top: 3rem; padding-bottom: 4rem;">
+    <section class="contact-intro">
+      <h1>Contact the Social Risk Audit team</h1>
+      <p>We welcome responsible disclosures, collaboration requests, and questions about privacy safeguards. Use the channel that best matches the urgency of your message and include only the information necessary for us to respond.</p>
+    </section>
+    <section class="contact-grid" aria-label="Contact options">
+      <article class="contact-card" id="general-inquiries">
+        <h2>General inquiries</h2>
+        <p>For most questions, community partnerships, or OSINT hygiene tips, email us at <a href="mailto:contact@osintsecrets.org" rel="nofollow">contact@osintsecrets.org</a>.</p>
+        <p>Including the details below helps us reply quickly:</p>
+        <ul>
+          <li>Summary of your request or question (2–3 sentences).</li>
+          <li>Relevant links, screenshots, or affected services.</li>
+          <li>Your preferred response window and contact method.</li>
+        </ul>
+        <p class="contact-meta">You can also reference this address in third-party vendor forms. Our inbox is monitored on business days (UTC).</p>
+      </article>
+      <article class="contact-card" id="urgent-escalations">
+        <h2>Urgent safety escalations</h2>
+        <p>If you believe someone is at immediate risk of doxxing, stalking, or coordinated harassment, flag it as <strong>URGENT</strong> in your subject line and email <a href="mailto:safety@osintsecrets.org" rel="nofollow">safety@osintsecrets.org</a>.</p>
+        <div class="urgent-note">
+          <p><strong>Include only essentials:</strong></p>
+          <ul>
+            <li>Who is affected and how we can reach them safely.</li>
+            <li>Links or identifiers that demonstrate the threat.</li>
+            <li>Any steps already taken (law enforcement, platform reports, etc.).</li>
+          </ul>
+          <p>We triage urgent mail 24/7. If a life-threatening emergency is in progress, contact local authorities first.</p>
+        </div>
+      </article>
+      <article class="contact-card" id="secure-options">
+        <h2>Secure follow-up options</h2>
+        <p>For sensitive disclosures or if you prefer end-to-end encryption, you can reach us on Matrix at <code>@osintsecrets:matrix.org</code> or via Signal at <code>+1-415-555-0119</code>.</p>
+        <p>When requesting our public key for file transfers, send an empty email to <a href="mailto:pgp@osintsecrets.org" rel="nofollow">pgp@osintsecrets.org</a> with the subject line “PGP request”. You will receive an automated reply containing our PGP fingerprint and policy for encrypted submissions.</p>
+        <p class="contact-meta">Secure channels are checked twice daily. Please note that we never request passwords, MFA codes, or payment information.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrapper footer-layout">
+      <nav class="footer-links" aria-label="Footer">
+        <a href="../">Home</a>
+        <a href="../index.html#self-audit">Self-audit</a>
+        <a href="../platform.html#tools-methods">Tools and Methods</a>
+        <a href="../platform.html">Platform</a>
+        <a href="../ethics.html">Ethics</a>
+        <a href="../why.html">Why</a>
+        <a href="../about/">About</a>
+        <a href="./" aria-current="page">Contact</a>
+        <a href="../disclaimer/">Disclaimer</a>
+      </nav>
+      <p>© 2025 OSINT Secrets</p>
+      <p class="ethics-footer-note"><a href="../ethics.html">Ethics</a> &amp; <a href="../disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>
+    </div>
+  </footer>
+  <script src="../assets/js/pledge-gate.js" defer></script>
+  <script src="../assets/js/main.js" defer></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', function () {
+      if (window.initEthicsBadge) {
+        window.initEthicsBadge();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -44,6 +44,7 @@
           <a href="../ethics.html" data-nav="ethics">Ethics</a>
           <a href="../why.html" data-nav="why">Why</a>
           <a href="../about/" data-nav="about">About</a>
+          <a href="../contact/" data-nav="contact">Contact</a>
           <a href="../disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -77,6 +78,7 @@
         <a href="../ethics.html">Ethics</a>
         <a href="../why.html">Why</a>
         <a href="../about/">About</a>
+        <a href="../contact/">Contact</a>
         <a href="../disclaimer/" aria-current="page">Disclaimer</a>
       </nav>
       <p>Built for privacy-first research and education.</p>

--- a/ethics.html
+++ b/ethics.html
@@ -22,6 +22,7 @@
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
           <a href="./why.html" data-nav="why">Why</a>
           <a href="./about/" data-nav="about">About</a>
+          <a href="./contact/" data-nav="contact">Contact</a>
           <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -99,6 +100,7 @@
         <a href="./ethics.html" aria-current="page">Ethics</a>
         <a href="./why.html">Why</a>
         <a href="./about/">About</a>
+        <a href="./contact/">Contact</a>
         <a href="./disclaimer/">Disclaimer</a>
       </nav>
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
           <a href="./why.html" data-nav="why">Why</a>
           <a href="./about/" data-nav="about">About</a>
+          <a href="./contact/" data-nav="contact">Contact</a>
           <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -67,6 +68,7 @@
         <a href="./ethics.html">Ethics</a>
         <a href="./why.html">Why</a>
         <a href="./about/">About</a>
+        <a href="./contact/">Contact</a>
         <a href="./disclaimer/">Disclaimer</a>
       </nav>
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>

--- a/platform.html
+++ b/platform.html
@@ -22,6 +22,7 @@
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
           <a href="./why.html" data-nav="why">Why</a>
           <a href="./about/" data-nav="about">About</a>
+          <a href="./contact/" data-nav="contact">Contact</a>
           <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -50,6 +51,7 @@
         <a href="./ethics.html">Ethics</a>
         <a href="./why.html">Why</a>
         <a href="./about/">About</a>
+        <a href="./contact/">Contact</a>
         <a href="./disclaimer/">Disclaimer</a>
       </nav>
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -3465,6 +3466,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -357,6 +358,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -348,6 +349,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -347,6 +348,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -343,6 +344,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -23,6 +23,7 @@
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
 <a data-nav="why" href="../why.html">Why</a>
 <a data-nav="about" href="../about/">About</a>
+<a data-nav="contact" href="../contact/">Contact</a>
 <a data-nav="disclaimer" href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>
@@ -348,6 +349,7 @@
 <a href="../ethics.html">Ethics</a>
 <a href="../why.html">Why</a>
 <a href="../about/">About</a>
+<a href="../contact/">Contact</a>
 <a href="../disclaimer/">Disclaimer</a>
 </nav>
 </div>

--- a/why.html
+++ b/why.html
@@ -22,6 +22,7 @@
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
           <a href="./why.html" data-nav="why">Why</a>
           <a href="./about/" data-nav="about">About</a>
+          <a href="./contact/" data-nav="contact">Contact</a>
           <a href="./disclaimer/" data-nav="disclaimer">Disclaimer</a>
         </nav>
       </div>
@@ -63,6 +64,7 @@
         <a href="./ethics.html">Ethics</a>
         <a href="./why.html" aria-current="page">Why</a>
         <a href="./about/">About</a>
+        <a href="./contact/">Contact</a>
         <a href="./disclaimer/">Disclaimer</a>
       </nav>
       <p class="ethics-footer-note"><a href="./ethics.html">Ethics</a> &amp; <a href="./disclaimer/">Disclaimer</a> • Last updated 2025-10-03 • Terms v1.0</p>


### PR DESCRIPTION
## Summary
- add a dedicated contact page covering general inquiries, urgent safety escalations, and secure contact options
- update shared header and footer navigation across the site to link to the new contact page
- extend the navigation script so the Contact link is marked active when appropriate

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df7933e7b8832399289eb302da7f6f