### PR TITLE
Add ethics badge assets to all content pages

### DIFF
--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -8,6 +8,8 @@
   <meta name="description" content="Important legal disclaimer for OSINT Secrets: educational purposes only.">
   <link rel="canonical" href="https://osintsecrets.github.io/PRIVACY/disclaimer/">
   <link rel="stylesheet" href="../assets/css/styles.css">
+  <link rel="stylesheet" href="../ethics-badge.css">
+  <script defer src="../ethics-badge.js"></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -84,5 +86,22 @@
   </footer>
   <script src="../assets/js/pledge-gate.js" defer></script>
   <script src="../assets/js/main.js" defer></script>
+  <script>
+    const triggerEthicsBadge = () => {
+      if (typeof window.initEthicsBadge === 'function') {
+        window.initEthicsBadge();
+        return true;
+      }
+      return false;
+    };
+    const scheduleEthicsBadge = () => {
+      if (!triggerEthicsBadge()) {
+        setTimeout(scheduleEthicsBadge, 50);
+      }
+    };
+    scheduleEthicsBadge();
+    document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+    window.addEventListener('load', triggerEthicsBadge);
+  </script>
 </body>
 </html>

--- a/ethics.html
+++ b/ethics.html
@@ -6,6 +6,8 @@
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Ethics</title>
   <link rel="stylesheet" href="./assets/css/styles.css">
+  <link rel="stylesheet" href="./ethics-badge.css">
+  <script defer src="./ethics-badge.js"></script>
 </head>
 <body>
   <header>
@@ -106,5 +108,22 @@
   </footer>
   <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
+  <script>
+    const triggerEthicsBadge = () => {
+      if (typeof window.initEthicsBadge === 'function') {
+        window.initEthicsBadge();
+        return true;
+      }
+      return false;
+    };
+    const scheduleEthicsBadge = () => {
+      if (!triggerEthicsBadge()) {
+        setTimeout(scheduleEthicsBadge, 50);
+      }
+    };
+    scheduleEthicsBadge();
+    document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+    window.addEventListener('load', triggerEthicsBadge);
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -86,11 +86,21 @@
     });
   </script>
   <script>
-    window.addEventListener('DOMContentLoaded', function () {
-      if (window.initEthicsBadge) {
+    const triggerEthicsBadge = () => {
+      if (typeof window.initEthicsBadge === 'function') {
         window.initEthicsBadge();
+        return true;
       }
-    });
+      return false;
+    };
+    const scheduleEthicsBadge = () => {
+      if (!triggerEthicsBadge()) {
+        setTimeout(scheduleEthicsBadge, 50);
+      }
+    };
+    scheduleEthicsBadge();
+    document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+    window.addEventListener('load', triggerEthicsBadge);
   </script>
 </body>
 </html>

--- a/platform.html
+++ b/platform.html
@@ -6,6 +6,8 @@
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Platforms</title>
   <link rel="stylesheet" href="./assets/css/styles.css">
+  <link rel="stylesheet" href="./ethics-badge.css">
+  <script defer src="./ethics-badge.js"></script>
 </head>
 <body>
   <header>
@@ -57,5 +59,22 @@
   </footer>
   <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
+  <script>
+    const triggerEthicsBadge = () => {
+      if (typeof window.initEthicsBadge === 'function') {
+        window.initEthicsBadge();
+        return true;
+      }
+      return false;
+    };
+    const scheduleEthicsBadge = () => {
+      if (!triggerEthicsBadge()) {
+        setTimeout(scheduleEthicsBadge, 50);
+      }
+    };
+    scheduleEthicsBadge();
+    document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+    window.addEventListener('load', triggerEthicsBadge);
+  </script>
 </body>
 </html>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — Facebook</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -3472,5 +3474,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — Instagram</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -364,5 +366,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — Telegram</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -355,5 +357,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — TikTok</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -354,5 +356,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — WhatsApp</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -350,5 +352,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -7,6 +7,8 @@
 <meta content="#0b0f14" name="theme-color"/>
 <title>Social Risk Audit — X (Twitter)</title>
 <link href="../assets/css/styles.css" rel="stylesheet"/>
+<link href="../ethics-badge.css" rel="stylesheet"/>
+<script defer src="../ethics-badge.js"></script>
 </head>
 <body>
 <header>
@@ -355,5 +357,22 @@
 <script defer="" src="../assets/js/pledge-gate.js"></script>
 <script defer="" src="../assets/js/platform-guides.js"></script>
 <script defer="" src="../assets/js/main.js"></script>
+<script>
+const triggerEthicsBadge = () => {
+  if (typeof window.initEthicsBadge === 'function') {
+    window.initEthicsBadge();
+    return true;
+  }
+  return false;
+};
+const scheduleEthicsBadge = () => {
+  if (!triggerEthicsBadge()) {
+    setTimeout(scheduleEthicsBadge, 50);
+  }
+};
+scheduleEthicsBadge();
+document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+window.addEventListener('load', triggerEthicsBadge);
+</script>
 </body>
 </html>

--- a/why.html
+++ b/why.html
@@ -6,6 +6,8 @@
   <meta name="theme-color" content="#0b0f14">
   <title>Social Risk Audit — Why Privacy</title>
   <link rel="stylesheet" href="./assets/css/styles.css">
+  <link rel="stylesheet" href="./ethics-badge.css">
+  <script defer src="./ethics-badge.js"></script>
 </head>
 <body>
   <header>
@@ -70,5 +72,22 @@
   </footer>
   <script src="./assets/js/pledge-gate.js" defer></script>
   <script src="./assets/js/main.js" defer></script>
+  <script>
+    const triggerEthicsBadge = () => {
+      if (typeof window.initEthicsBadge === 'function') {
+        window.initEthicsBadge();
+        return true;
+      }
+      return false;
+    };
+    const scheduleEthicsBadge = () => {
+      if (!triggerEthicsBadge()) {
+        setTimeout(scheduleEthicsBadge, 50);
+      }
+    };
+    scheduleEthicsBadge();
+    document.addEventListener('DOMContentLoaded', triggerEthicsBadge);
+    window.addEventListener('load', triggerEthicsBadge);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include the shared ethics badge stylesheet and script on the platform, ethics, why, and disclaimer pages as well as every nested platform guide
- add a resilient initialization helper so each page automatically mounts the ethics badge once the script is available
- confirmed the badge renders and toggles correctly on a nested platform page after accepting the pledge gate

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68df72cade588323bc6318fd53a15213