### PR TITLE
Remove self-audit navigation entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A stripped-back, utility-first privacy guide for the Platform checklist with eth
 
 ## Pages
 
-- **Home** – mission statement, overview, and quick links to core content.
+- **Home** – mission statement, overview, and interactive self-audit checklists.
 - **Platform** – expandable checklists for essential privacy tasks.
 - **Ethics** – principles that guide how the material should be used.
 - **Why** – rationale for caring about privacy in plain language.

--- a/about/index.html
+++ b/about/index.html
@@ -52,7 +52,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="../" data-nav="home">Home</a>
-          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="../platform.html" data-nav="platform">Platform</a>
           <a href="../ethics.html" data-nav="ethics">Ethics</a>
@@ -139,7 +138,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="../">Home</a>
-        <a href="../index.html#self-audit">Self-audit</a>
         <a href="../platform.html#tools-methods">Tools and Methods</a>
         <a href="../platform.html">Platform</a>
         <a href="../ethics.html">Ethics</a>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -79,11 +79,9 @@
   if (!normalized.startsWith('/')) normalized = normalized ? `/${normalized}` : '/';
   let current = null;
   const hash = location.hash;
-  if (hash === '#self-audit') current = 'self-audit';
-  else if (hash === '#tools-methods') current = 'tools';
+  if (hash === '#tools-methods') current = 'tools';
   if (!current) {
     if (normalized === '/' || normalized === '') current = 'home';
-    else if (normalized === '/self-audit/' || normalized === '/self-audit') current = 'self-audit';
     else if (normalized === '/tools-and-methods/' || normalized === '/tools-and-methods') current = 'tools';
     else if (normalized === '/platform.html') current = 'platform';
     else if (normalized.startsWith('/platforms/')) current = 'platform';

--- a/contact/index.html
+++ b/contact/index.html
@@ -97,7 +97,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="../" data-nav="home">Home</a>
-          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="../platform.html" data-nav="platform">Platform</a>
           <a href="../ethics.html" data-nav="ethics">Ethics</a>
@@ -153,7 +152,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="../">Home</a>
-        <a href="../index.html#self-audit">Self-audit</a>
         <a href="../platform.html#tools-methods">Tools and Methods</a>
         <a href="../platform.html">Platform</a>
         <a href="../ethics.html">Ethics</a>

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -40,7 +40,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="../" data-nav="home">Home</a>
-          <a href="../index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="../platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="../platform.html" data-nav="platform">Platform</a>
           <a href="../ethics.html" data-nav="ethics">Ethics</a>
@@ -74,7 +73,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="../">Home</a>
-        <a href="../index.html#self-audit">Self-audit</a>
         <a href="../platform.html#tools-methods">Tools and Methods</a>
         <a href="../platform.html">Platform</a>
         <a href="../ethics.html">Ethics</a>

--- a/ethics.html
+++ b/ethics.html
@@ -18,7 +18,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="./" data-nav="home">Home</a>
-          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="./platform.html" data-nav="platform">Platform</a>
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
@@ -96,7 +95,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="./">Home</a>
-        <a href="./index.html#self-audit">Self-audit</a>
         <a href="./platform.html#tools-methods">Tools and Methods</a>
         <a href="./platform.html">Platform</a>
         <a href="./ethics.html" aria-current="page">Ethics</a>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="./" data-nav="home">Home</a>
-          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="./platform.html" data-nav="platform">Platform</a>
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
@@ -185,7 +184,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="./">Home</a>
-        <a href="./index.html#self-audit">Self-audit</a>
         <a href="./platform.html#tools-methods">Tools and Methods</a>
         <a href="./platform.html">Platform</a>
         <a href="./ethics.html">Ethics</a>

--- a/platform.html
+++ b/platform.html
@@ -18,7 +18,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="./" data-nav="home">Home</a>
-          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="./platform.html" data-nav="platform">Platform</a>
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
@@ -47,7 +46,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="./">Home</a>
-        <a href="./index.html#self-audit">Self-audit</a>
         <a href="./platform.html#tools-methods">Tools and Methods</a>
         <a href="./platform.html">Platform</a>
         <a href="./ethics.html">Ethics</a>

--- a/platforms/facebook.html
+++ b/platforms/facebook.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -3462,7 +3461,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -354,7 +353,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/platforms/telegram.html
+++ b/platforms/telegram.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -345,7 +344,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/platforms/tiktok.html
+++ b/platforms/tiktok.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -344,7 +343,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/platforms/whatsapp.html
+++ b/platforms/whatsapp.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -340,7 +339,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -19,7 +19,6 @@
 <button aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="menu-toggle">☰</button>
 <nav aria-label="Primary" class="menu" hidden="" id="site-menu">
 <a data-nav="home" href="../">Home</a>
-<a data-nav="self-audit" href="../index.html#self-audit">Self-audit</a>
 <a data-nav="tools" href="../platform.html#tools-methods">Tools and Methods</a>
 <a data-nav="platform" href="../platform.html">Platform</a>
 <a data-nav="ethics" href="../ethics.html">Ethics</a>
@@ -345,7 +344,6 @@
 <p>Utility-first build — no trackers.</p>
 <nav aria-label="Footer" class="footer-links">
 <a href="../">Home</a>
-<a href="../index.html#self-audit">Self-audit</a>
 <a href="../platform.html#tools-methods">Tools and Methods</a>
 <a href="../platform.html">Platform</a>
 <a href="../ethics.html">Ethics</a>

--- a/why.html
+++ b/why.html
@@ -18,7 +18,6 @@
         <button class="menu-toggle" aria-controls="site-menu" aria-expanded="false" aria-haspopup="true" aria-label="Open menu">☰</button>
         <nav id="site-menu" class="menu" hidden aria-label="Primary">
           <a href="./" data-nav="home">Home</a>
-          <a href="./index.html#self-audit" data-nav="self-audit">Self-audit</a>
           <a href="./platform.html#tools-methods" data-nav="tools">Tools and Methods</a>
           <a href="./platform.html" data-nav="platform">Platform</a>
           <a href="./ethics.html" data-nav="ethics">Ethics</a>
@@ -60,7 +59,6 @@
     <div class="wrapper footer-layout">
       <nav class="footer-links" aria-label="Footer">
         <a href="./">Home</a>
-        <a href="./index.html#self-audit">Self-audit</a>
         <a href="./platform.html#tools-methods">Tools and Methods</a>
         <a href="./platform.html">Platform</a>
         <a href="./ethics.html">Ethics</a>


### PR DESCRIPTION
## Summary
- remove the self-audit link from the shared header and footer navigation across the site
- update the navigation script so it no longer tracks the self-audit menu item
- refresh the README home description to highlight the on-page self-audit checklists

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68df91e1f0f883238ce871bea9963217