### PR TITLE
Add automated mobile and desktop audit coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Node & Playwright artifacts
+node_modules/
+playwright-report/
+test-results/

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -25,3 +25,4 @@
 | Links respect `/PRIVACY/` base path | ✅ | Navigation and buttons use absolute prefixed URLs. |
 | No external fonts or trackers | ✅ | System font stack defined; no third-party scripts. |
 | Mobile tap targets ≥44px | ✅ | Buttons and nav links enforce min-height and padding. |
+| Automated responsiveness audit | ✅ | Playwright tests cover desktop/mobile viewports, page load errors, and mobile nav toggling. |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ To verify the offline shell:
 2. Stop the local server or toggle the browser's network inspector to “offline”.
 3. Reload any page—navigation should fall back to `offline.html`.
 
+## Automated audits
+
+Run the Playwright-powered audit suite to exercise every public page at desktop and mobile breakpoints, confirm viewport/responsive metadata, and verify the navigation menu behaves on touch layouts:
+
+```bash
+npm install
+npm test
+```
+
+> The tests start a temporary `python -m http.server` instance and rely on Chromium. If the bundled browser download is blocked on your network, manually provide a Chromium binary and re-run `npm test`.
+
 ## Accessibility & privacy
 
 - System font stack, high-contrast palette, and consistent focus outlines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "privacy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "privacy",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "social-risk-audit",
+  "version": "1.0.0",
+  "description": "Static Social Risk Audit site with automated responsiveness audits",
+  "license": "MIT",
+  "type": "commonjs",
+  "scripts": {
+    "test": "playwright test",
+    "test:audit": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,40 @@
+// @ts-check
+const { devices } = require('@playwright/test');
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  testDir: './tests',
+  timeout: 60 * 1000,
+  expect: {
+    timeout: 10 * 1000,
+  },
+  fullyParallel: true,
+  retries: 0,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    cwd: '.',
+    timeout: 60 * 1000,
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'mobile-chromium',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/tests/audit.spec.js
+++ b/tests/audit.spec.js
@@ -1,0 +1,95 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const TERMS_VERSION = 'v1.0 (2025-10-03)';
+const TOKEN_KEY = 'ETHICS_PLEDGE_TOKEN';
+const TERMS_VERSION_KEY = 'TERMS_VERSION';
+
+const ROUTES = [
+  '/',
+  '/index.html',
+  '/why.html',
+  '/ethics.html',
+  '/platform.html',
+  '/platforms/facebook.html',
+  '/platforms/instagram.html',
+  '/platforms/telegram.html',
+  '/platforms/tiktok.html',
+  '/platforms/x.html',
+  '/platforms/whatsapp.html',
+  '/about/',
+  '/contact/',
+  '/disclaimer/',
+  '/pledge.html',
+  '/access-denied.html',
+  '/offline.html',
+  '/404.html',
+];
+
+async function grantPledge(page) {
+  await page.addInitScript(({ tokenKey, termsKey, version }) => {
+    try {
+      const payload = { token: 'test-token', version, createdAt: new Date().toISOString() };
+      window.sessionStorage.setItem(tokenKey, JSON.stringify(payload));
+      window.sessionStorage.setItem(termsKey, version);
+    } catch (error) {
+      console.warn('Unable to seed pledge token in test environment', error);
+    }
+  }, { tokenKey: TOKEN_KEY, termsKey: TERMS_VERSION_KEY, version: TERMS_VERSION });
+}
+
+test.beforeEach(async ({ page }) => {
+  await grantPledge(page);
+});
+
+for (const route of ROUTES) {
+  test.describe(`page audit: ${route}`, () => {
+    test(`loads without console errors`, async ({ page }) => {
+      const errors = [];
+      page.on('console', (message) => {
+        if (message.type() === 'error') {
+          errors.push(message.text());
+        }
+      });
+
+      const response = await page.goto(route, { waitUntil: 'networkidle' });
+      expect(response, `No response for ${route}`).not.toBeNull();
+      expect(response?.ok(), `Response was not OK for ${route}`).toBeTruthy();
+
+      await expect(page.locator('body')).toBeVisible();
+
+      const viewportMetaCount = await page.locator('head meta[name="viewport"]').count();
+      expect(viewportMetaCount, 'Viewport meta tag missing').toBeGreaterThan(0);
+
+      const hasHorizontalOverflow = await page.evaluate(() => {
+        const doc = document.documentElement;
+        return doc.scrollWidth > doc.clientWidth + 1;
+      });
+      expect(hasHorizontalOverflow, 'Page should not overflow horizontally at default zoom').toBeFalsy();
+
+      expect(errors, `Console errors detected on ${route}:\n${errors.join('\n')}`).toEqual([]);
+    });
+  });
+}
+
+test.describe('mobile navigation', () => {
+  test('menu toggle opens and closes', async ({ page }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('mobile'), 'Mobile-only assertion');
+
+    await page.goto('/');
+
+    const toggle = page.locator('.menu-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    const menu = page.locator('#site-menu');
+    await expect(menu).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await toggle.click();
+    await expect(menu).toBeHidden();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright audit config and coverage for every public page plus mobile navigation behaviour
- document the new responsive audit workflow and record the added coverage in the project notes
- ignore node-based artefacts generated by the new tooling

## Testing
- npm test *(fails: Playwright Chromium binary download is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfef0687808323afd83caa75373eb6