### PR TITLE
Document audit attempt blocked by missing browsers

### DIFF
--- a/audit-log-2025-10-03.md
+++ b/audit-log-2025-10-03.md
@@ -1,0 +1,25 @@
+# Automated Audit Run — 2025-10-03
+
+## Summary
+- Installed project dependencies with `npm install`.
+- Attempted to run the full Playwright regression suite via `npm test`.
+- Test runner failed immediately because the Chromium browser binary was not present in the environment and Playwright could not download it.
+- Additional attempts to install Chromium (via `npx playwright install chromium` and `apt-get install chromium-browser`) were blocked by upstream network restrictions on required binaries/snaps.
+
+## Detailed Steps
+1. `npm install`
+   - Completed successfully and reported zero vulnerabilities.
+2. `npm test`
+   - Playwright attempted to launch Chromium for each project and failed with `Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1148/chrome-linux/headless_shell`.
+   - Playwright reported that browsers need to be installed with `npx playwright install`.
+3. `npx playwright install chromium`
+   - Download attempts from the official Playwright CDN (`playwright.azureedge.net`) returned HTTP 403 `Domain forbidden` responses, preventing installation.
+4. `apt-get install chromium-browser`
+   - The Ubuntu transitional package installs a wrapper that relies on the Snap store.
+   - Snap installation could not complete inside the container (`System doesn't have a working snapd, skipping`), leaving Chromium unavailable.
+
+## Next Actions for a Successful Local Audit
+- Re-run `npx playwright install chromium` from an environment with access to Playwright's CDN, or
+- Provide a pre-installed Chromium binary and set `PLAYWRIGHT_BROWSERS_PATH` or `executablePath` in `playwright.config.js` accordingly.
+
+Once Chromium is available, rerun `npm test` to execute the complete audit suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "privacy",
+  "name": "social-risk-audit",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "privacy",
+      "name": "social-risk-audit",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.49.0"
       }


### PR DESCRIPTION
## Summary
- add an audit log capturing the 2025-10-03 Playwright regression attempt and follow-up guidance for missing browser binaries
- update lockfile metadata to stay in sync with package.json after installing dependencies

## Testing
- npm test *(fails: Playwright could not download Chromium in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e00c6befb883238036529320ce5020