### PR TITLE
Make service worker use dynamic base path

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,13 +1,15 @@
 const CACHE_VERSION = 'v1';
 const CORE_CACHE = `sra-core-${CACHE_VERSION}`;
-const OFFLINE_URL = '/PRIVACY/offline.html';
+const base = new URL('./', self.registration.scope);
+const withBase = (path) => new URL(path, base).toString();
+const OFFLINE_URL = withBase('offline.html');
 
 const PRECACHE_URLS = [
-  '/PRIVACY/',
-  '/PRIVACY/index.html',
-  '/PRIVACY/offline.html',
-  '/PRIVACY/assets/css/styles.css',
-  '/PRIVACY/assets/js/main.js',
+  withBase(''),
+  withBase('index.html'),
+  OFFLINE_URL,
+  withBase('assets/css/styles.css'),
+  withBase('assets/js/main.js'),
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- derive the service worker cache base from the registration scope
- build offline and precache URLs dynamically so deployments outside /PRIVACY/ keep working

## Testing
- python -m http.server
- npx playwright test *(fails: missing Playwright browsers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23fac45788323835531fa2da9954a