### PR TITLE
Raise header layering and improve pledge badge visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -6,13 +6,13 @@ body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 var(--font-sa
 a{color:var(--accent);}a:hover{text-decoration:underline;}
 a:focus-visible{outline:2px solid var(--accent);outline-offset:3px;}
 .wrapper{max-width:72ch;margin:0 auto;padding:calc(var(--space)*2) var(--space);}
-header{position:sticky;top:0;z-index:10;background:#0c1117;border-bottom:1px solid var(--border);}
+header{position:sticky;top:0;z-index:var(--z-header,10);background:#0c1117;border-bottom:1px solid var(--border);}
 .header-row{display:flex;align-items:center;justify-content:space-between;gap:var(--space);}
 .brand{color:var(--text);text-decoration:none;font-weight:700;}
 .menu-toggle{background:#0e1820;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;min-width:44px;min-height:44px;}
 .menu-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
 .menu-container{position:relative;display:flex;align-items:center;}
-.menu{display:flex;flex-direction:column;gap:6px;padding:12px;background:#0e151b;border:1px solid var(--border);border-radius:12px;position:absolute;top:calc(100% + 10px);right:0;width:min(240px,calc(100vw - var(--space)*2));box-shadow:0 18px 40px rgba(0,0,0,0.45);z-index:20;}
+.menu{display:flex;flex-direction:column;gap:6px;padding:12px;background:#0e151b;border:1px solid var(--border);border-radius:12px;position:absolute;top:calc(100% + 10px);right:0;width:min(240px,calc(100vw - var(--space)*2));box-shadow:0 18px 40px rgba(0,0,0,0.45);z-index:var(--z-menu,20);pointer-events:auto;}
 .menu::before{content:"";position:absolute;top:-10px;right:18px;width:16px;height:16px;transform:rotate(45deg);background:#0e151b;border-left:1px solid var(--border);border-top:1px solid var(--border);z-index:19;}
 .menu a{display:block;padding:10px 12px;border-radius:10px;color:var(--muted);text-decoration:none;position:relative;z-index:1;}
 .menu a[aria-current="page"]{background:#0f1b20;color:var(--text);}
@@ -161,79 +161,65 @@ nav.card ol { padding-left: 1.25rem; }
 .back-to-top{right:16px;bottom:16px;}
 }
 :root {
-  --z-header: 100;
-  --z-overlay: 1000;
-  --z-menu: 1100;
-  --z-dialog: 2000;
-}
-header { position: sticky; top: 0; z-index: var(--z-header); }
-#ui-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: var(--z-overlay); opacity: 0; pointer-events: none; }
-#ui-overlay[aria-hidden="false"] { opacity: 1; pointer-events: auto; }
-.menu { position: absolute; top: 100%; right: 0; z-index: var(--z-menu); background: var(--card); }
-dialog { z-index: var(--z-dialog); }
-body.is-locked { overflow: hidden; }
-/* Layering system */
-:root { --z-header: 100; --z-overlay: 1000; --z-menu: 1100; --z-dialog: 2000; }
-header { position: sticky; top: 0; z-index: var(--z-header); }
-#ui-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: var(--z-overlay); opacity: 0; pointer-events: none; transition: opacity .15s ease; }
-#ui-overlay[aria-hidden="false"] { opacity: 1; pointer-events: auto; }
-.menu { position: absolute; top: calc(100% + 10px); right: 0; z-index: var(--z-menu); }
-dialog { z-index: var(--z-dialog); }
-body.is-locked { overflow: hidden; position: relative; touch-action: none; }
-
-/* Focus visibility */
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-/* RTL positioning */
-html[dir="rtl"] .menu { right: auto; left: 0; }
-
-/* Optional: Dialog base if not present */
-dialog { border:1px solid var(--border); border-radius:12px; padding:1rem 1.25rem; background:var(--card); color:var(--text); max-width:min(680px, 90vw); }
-dialog::backdrop { background: rgba(0,0,0,.5); }
-
-/* ---- Layering scale (bumped for safety) ---- */
-:root {
-  --z-header: 1200;   /* sticky header baseline */
-  --z-overlay: 1500;  /* page-dimming overlay */
-  --z-menu: 2000;     /* header dropdown menu */
-  --z-dialog: 3000;   /* modal dialogs */
+  --z-overlay: 2000;   /* page-dimming overlay */
+  --z-header: 2500;    /* sticky header and its children */
+  --z-menu: 2600;      /* header dropdown menu (inside header) */
+  --z-dialog: 3000;    /* modal dialogs */
 }
 
-/* Ensure menu creates its own stacking context above overlay */
+/* Header sits above overlay so dropdown is clickable */
+header { position: sticky; top: 0; z-index: var(--z-header); }
+
+/* Menu is within header; ensure it is on top of the header layer */
 .menu-container { position: relative; isolation: isolate; }
 .menu {
   position: absolute;
   top: calc(100% + 10px);
   right: 0;
   z-index: var(--z-menu);
-  pointer-events: auto; /* guarantee interactivity */
+  pointer-events: auto;
 }
 
-/* Overlay always below menu, above page */
+/* Overlay below header/menu, above rest of page */
 #ui-overlay {
-  position: fixed; inset: 0;
+  position: fixed;
+  inset: 0;
   background: rgba(0,0,0,.55);
   z-index: var(--z-overlay);
-  opacity: 0; pointer-events: none; transition: opacity .15s ease;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s ease;
 }
 #ui-overlay[aria-hidden="false"] { opacity: 1; pointer-events: auto; }
 
-/* Lock scroll while any overlay/menu is open */
+/* Lock background scroll while menu/dialog open */
 body.is-locked { overflow: hidden; position: relative; touch-action: none; }
 
-/* Dialog above everything + visual polish */
-dialog { z-index: var(--z-dialog); box-shadow: 0 24px 60px rgba(0,0,0,.5); }
+/* Dialogs stay top-most */
+dialog {
+  z-index: var(--z-dialog);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: var(--card);
+  color: var(--text);
+  max-width: min(680px, 90vw);
+  box-shadow: 0 24px 60px rgba(0,0,0,.5);
+}
+dialog::backdrop { background: rgba(0,0,0,.5); }
 dialog article { display: flex; flex-direction: column; gap: 16px; }
 dialog h2 { margin: 0; font-size: clamp(20px, 3.6vw, 28px); }
 dialog p { margin: 0; color: var(--muted); font-size: 1.05rem; }
 .button-group { display: flex; gap: 12px; flex-wrap: wrap; }
 
-/* Keep menu clickable even when nested inside header */
-header { position: sticky; top: 0; z-index: var(--z-header); }
+/* ---- Pledge badge (pill) visibility & contrast ---- */
+.pill { display:inline-flex; align-items:center; gap:.35rem; padding:.35rem .7rem; border:1px solid var(--border); border-radius:999px; font-weight:600; line-height:1; }
+#pledgeStatus.pill { background: var(--card); color: var(--text); box-shadow: 0 2px 6px rgba(0,0,0,.18); }
+@media (max-width: 420px){ #pledgeStatus.pill { font-size:.85rem; } }
 
-/* Optional: clearer hover click target in menu */
-#site-menu a { padding: 10px 12px; border-radius: 10px; }
-#site-menu a:hover { background: #0f1f26; }
+/* Optional: nicer hover focus for menu items */
+#site-menu a { padding:10px 12px; border-radius:10px; }
+#site-menu a:hover, #site-menu a:focus-visible { background:#0f1f26; }
 
 /* RTL alignment for dropdown */
-html[dir="rtl"] .menu { right: auto; left: 0; }
+html[dir="rtl"] .menu { right:auto; left:0; }


### PR DESCRIPTION
## Summary
- raise the header, menu, and overlay stacking order with shared CSS variables so the dropdown remains clickable
- ensure overlays lock page scroll and dialogs stay on top while polishing menu item focus styles
- improve the pledge status pill contrast and responsiveness

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e25ea82fcc8323926ffaa20df181b8