### PR TITLE
Add local gamification to self-audit flow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -269,3 +269,23 @@ html[dir="rtl"] .select { padding: 10px 12px 10px 38px; background-position: lef
   .mission { break-inside: avoid; box-shadow:none; border-color:#b8cbd0; }
   .progress { display:none; }
 }
+
+/* HUD */
+.hud { display:flex; gap:12px; align-items:center; margin:10px 0 16px; }
+.hud-item { display:flex; align-items:center; gap:6px; padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:var(--card); box-shadow:0 2px 8px rgba(0,0,0,.18); }
+.hud-item .label { font-size:.8rem; color:var(--muted); text-transform:uppercase; letter-spacing:.06em; }
+.hud-item .value { font-weight:800; font-variant-numeric:tabular-nums; }
+
+/* Mission header progress accent (visual feedback per phase) */
+.mission { position:relative; }
+.mission::before { content:""; position:absolute; inset:0 0 auto 0; height:4px; background:linear-gradient(90deg,#2fb171,#53d1a0); width:var(--phase-pct,0%); border-top-left-radius:10px; border-top-right-radius:10px; }
+
+/* Locked state (for linear mode) */
+.mission.is-locked { opacity:.55; filter:saturate(.7); }
+.mission.is-locked .quest, .mission.is-locked .actions, .mission.is-locked .note { pointer-events:none; }
+
+/* Achievements */
+.achievements { margin-top:24px; }
+.ach-list { display:grid; gap:6px; grid-template-columns:1fr; }
+@media(min-width:560px){ .ach-list{ grid-template-columns:repeat(2, minmax(0,1fr)); } }
+.ach-list li { list-style:none; padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:var(--card); box-shadow:0 2px 8px rgba(0,0,0,.12); }

--- a/assets/js/self-audit.js
+++ b/assets/js/self-audit.js
@@ -1,64 +1,181 @@
 (function(){
   const KEY = 'sra_self_audit_v1';
+  const CONFIG = {
+    xpPerQuest: 5,
+    xpPhaseBonus: 20,
+    linear: false, // set to true to lock phases sequentially (D → A → R → K)
+  };
+
   const $ = (s, r=document)=>r.querySelector(s);
   const $$ = (s, r=document)=>Array.from(r.querySelectorAll(s));
 
   const state = load();
   hydrate();
-  updateOverall();
+  wireMissions();
+  recalcAll();
 
-  // Event wiring
-  $$('.mission').forEach(m => {
-    const phase = m.getAttribute('data-phase');
-    // Checkboxes
-    $$('.quest input', m).forEach(cb => {
-      cb.checked = !!state.quests[cb.dataset.quest];
-      cb.addEventListener('change', () => { state.quests[cb.dataset.quest] = cb.checked; persist(); updatePhaseXP(m, phase); updateOverall(); });
+  // ------------ wiring ------------
+  function wireMissions(){
+    $$('.mission').forEach(m => {
+      const phase = m.getAttribute('data-phase');
+      const prior = prevPhase(phase);
+
+      // Linear lock control
+      if (CONFIG.linear && prior && !state.phases[prior]) {
+        m.classList.add('is-locked');
+        $$('input,button,textarea,a', m).forEach(el => el.setAttribute('disabled',''));
+      } else {
+        m.classList.remove('is-locked');
+        $$('input,button,textarea,a', m).forEach(el => el.removeAttribute('disabled'));
+      }
+
+      // Checkboxes
+      $$('.quest input', m).forEach(cb => {
+        cb.checked = !!state.quests[cb.dataset.quest];
+        cb.addEventListener('change', () => {
+          state.quests[cb.dataset.quest] = cb.checked;
+          persist();
+          recalcPhase(m, phase);
+          recalcAll();
+        });
+      });
+
+      // Note
+      const ta = $('.note', m);
+      if (ta){
+        ta.value = state.notes[phase] || '';
+        ta.addEventListener('input', ()=>{ state.notes[phase] = ta.value; persist(); stamp(); });
+      }
+
+      // Complete / Reset
+      $('[data-complete]', m)?.addEventListener('click', ()=>{
+        state.phases[phase] = true;
+        persist();
+        recalcPhase(m, phase);
+        wireMissions(); // unlock next if linear
+        recalcAll();
+      });
+      $('[data-reset]', m)?.addEventListener('click', ()=>{
+        resetPhase(phase, m);
+        wireMissions();
+        recalcAll();
+      });
+
+      recalcPhase(m, phase);
     });
-    // Note
-    const ta = $('.note', m);
-    if (ta){ ta.value = state.notes[phase] || ''; ta.addEventListener('input', ()=>{ state.notes[phase] = ta.value; persist(); stamp(); }); }
-    // Complete / Reset
-    const complete = $('[data-complete]', m);
-    const reset = $('[data-reset]', m);
-    complete?.addEventListener('click', ()=>{ state.phases[phase] = true; persist(); updatePhaseXP(m, phase); updateOverall(); });
-    reset?.addEventListener('click', ()=>{ deletePhase(phase, m); persist(); updatePhaseXP(m, phase); updateOverall(); });
-    // Initial XP state
-    updatePhaseXP(m, phase);
-  });
 
-  $('#resetAll')?.addEventListener('click', ()=>{ localStorage.removeItem(KEY); location.reload(); });
-
-  function deletePhase(phase, m){
-    // Uncheck checkboxes in UI and state
-    $$('.quest input', m).forEach(cb => { cb.checked = false; delete state.quests[cb.dataset.quest]; });
-    const ta = $('.note', m); if (ta){ ta.value = ''; delete state.notes[phase]; }
-    state.phases[phase] = false;
+    $('#resetAll')?.addEventListener('click', ()=>{ localStorage.removeItem(KEY); location.reload(); });
   }
 
-  function updatePhaseXP(m, phase){
-    const done = $$('.quest input', m).filter(cb=>cb.checked).length;
-    const total = $$('.quest input', m).length || 1;
+  // ------------ calculations ------------
+  function recalcPhase(m, phase){
+    const cbs = $$('.quest input', m);
+    const done = cbs.filter(cb=>cb.checked).length;
+    const total = cbs.length || 1;
     const pct = Math.round((done/total)*100);
+
     const badge = $('[data-phase-xp]', m);
     if (badge) badge.textContent = phase + ' ' + pct + '%';
+
+    // XP for this phase
+    const phaseXp = done * CONFIG.xpPerQuest + (state.phases[phase] ? CONFIG.xpPhaseBonus : 0);
+    m.setAttribute('data-xp', String(phaseXp));
+
+    // Phase header meter style
+    m.style.setProperty('--phase-pct', pct + '%');
   }
 
-  function updateOverall(){
+  function recalcAll(){
+    // Overall progress
     const allCbs = $$('.quest input');
     const done = allCbs.filter(cb=>cb.checked).length;
     const total = allCbs.length || 1;
     const pct = Math.round((done/total)*100);
-    $('#overallFill').style.width = pct + '%';
-    $('#overallPct').textContent = pct + '%';
+    const fill = $('#overallFill');
+    if (fill) fill.style.width = pct + '%';
+    const pctEl = $('#overallPct');
+    if (pctEl) pctEl.textContent = pct + '%';
+
+    // XP total
+    const xp = sumXP();
+    const xpEl = $('#xpTotal');
+    if (xpEl) xpEl.textContent = xp;
+
+    // Threat meter label
+    const threat = threatLabel(pct);
+    const tl = $('#threatLabel');
+    if (tl) tl.textContent = threat;
+
+    // Achievements
+    updateAchievements(pct);
+
+    // timestamp
     stamp();
   }
 
+  function sumXP(){
+    let xp = 0;
+    $$('.mission').forEach(m => { xp += Number(m.getAttribute('data-xp')||0); });
+    return xp;
+  }
+
+  function threatLabel(pct){
+    if (pct < 25) return 'Exposed';
+    if (pct < 70) return 'Hardening';
+    return 'Hardened';
+  }
+
+  function updateAchievements(pct){
+    const a = state.ach || (state.ach = {});
+    const list = $('#achList');
+    if (!list) return;
+
+    function unlock(key, label){ if (!a[key]) { a[key] = true; pushAch(label); persist(); } }
+    function pushAch(label){ const li = document.createElement('li'); li.textContent = label; list.appendChild(li); }
+
+    // Clear and redraw current
+    list.innerHTML = '';
+    Object.entries(a).forEach(([k,v])=>{ if (v) pushAch(labelFor(k)); });
+
+    // Check unlocks
+    if (sumXP() >= 10) unlock('first_steps','First Steps');
+    if (phaseDone('D')) unlock('discovery','Discovery Done');
+    if (phaseDone('A')) unlock('analyzer','Analyzer');
+    if (phaseDone('R')) unlock('reducer','Reducer');
+    if (phaseDone('K')) unlock('keeper','Keeper');
+    if (pct === 100) unlock('perfect','100% Completion');
+  }
+
+  function phaseDone(p){ return !!state.phases[p]; }
+  function prevPhase(p){ return ({A:'D', R:'A', K:'R'})[p] || null; }
+
+  // ------------ persistence & meta ------------
   function load(){
-    try{ return JSON.parse(localStorage.getItem(KEY)) || { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ts:null }; }
-    catch(e){ return { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ts:null }; }
+    try{ return JSON.parse(localStorage.getItem(KEY)) || { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null }; }
+    catch(e){ return { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null }; }
   }
   function persist(){ localStorage.setItem(KEY, JSON.stringify(state)); }
   function stamp(){ const el = document.getElementById('lastUpdated'); if (!el) return; const d = new Date(); state.ts = d.toISOString(); persist(); el.textContent = 'Last updated: ' + d.toLocaleString(); }
   function hydrate(){ if (state.ts){ const d = new Date(state.ts); const el = document.getElementById('lastUpdated'); if (el) el.textContent = 'Last updated: ' + d.toLocaleString(); } }
+
+  // ------------ reset helpers ------------
+  function resetPhase(phase, m){
+    $$('.quest input', m).forEach(cb => { cb.checked = false; delete state.quests[cb.dataset.quest]; });
+    const ta = $('.note', m); if (ta){ ta.value = ''; delete state.notes[phase]; }
+    state.phases[phase] = false;
+    persist();
+    recalcPhase(m, phase);
+  }
+
+  function labelFor(key){
+    switch (key){
+      case 'first_steps': return 'First Steps';
+      case 'discovery': return 'Discovery Done';
+      case 'analyzer': return 'Analyzer';
+      case 'reducer': return 'Reducer';
+      case 'keeper': return 'Keeper';
+      case 'perfect': return '100% Completion';
+      default: return key;
+    }
+  }
 })();

--- a/self-audit.html
+++ b/self-audit.html
@@ -65,6 +65,11 @@
       </div>
     </section>
 
+    <section class="hud" aria-label="Status">
+      <div class="hud-item"><span class="label">XP</span><span id="xpTotal" class="value">0</span></div>
+      <div class="hud-item"><span class="label">Threat</span><span id="threatLabel" class="value">Exposed</span></div>
+    </section>
+
     <!-- Overview Cards -->
     <section class="missions" aria-label="DARK missions">
       <article class="mission" data-phase="D">
@@ -144,6 +149,11 @@
     <section class="prose" style="margin-top:18px">
       <button class="button" id="resetAll">Reset All Progress</button>
       <span class="pill" id="lastUpdated">Last updated: —</span>
+    </section>
+
+    <section class="prose achievements" aria-labelledby="achTitle">
+      <h2 id="achTitle">Achievements</h2>
+      <ul id="achList" class="ach-list"></ul>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- add a HUD to the self-audit page that tracks XP totals and threat status
- gamify mission progression with XP, achievements, and optional linear phase locking stored in localStorage
- polish mission styling and introduce an achievements list for completed milestones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2964121b08323af03775741aba861