### PR TITLE
feat: streamline self-audit flow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -281,7 +281,7 @@ html[dir="rtl"] .select { padding: 10px 12px 10px 38px; background-position: lef
 .mission::before { content:""; position:absolute; inset:0 0 auto 0; height:4px; background:linear-gradient(90deg,#2fb171,#53d1a0); width:var(--phase-pct,0%); border-top-left-radius:10px; border-top-right-radius:10px; }
 
 /* Locked state (for linear mode) */
-.mission.is-locked { opacity:.55; filter:saturate(.7); }
+.mission.is-locked { opacity:.6; filter:saturate(.7); }
 .mission.is-locked .quest, .mission.is-locked .actions, .mission.is-locked .note { pointer-events:none; }
 
 /* Achievements */
@@ -289,3 +289,29 @@ html[dir="rtl"] .select { padding: 10px 12px 10px 38px; background-position: lef
 .ach-list { display:grid; gap:6px; grid-template-columns:1fr; }
 @media(min-width:560px){ .ach-list{ grid-template-columns:repeat(2, minmax(0,1fr)); } }
 .ach-list li { list-style:none; padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:var(--card); box-shadow:0 2px 8px rgba(0,0,0,.12); }
+
+/* Cleaner layout + calmer visuals */
+.wrapper { max-width: 1040px; }
+.missions.wizard { margin-top: 12px; }
+.mission { box-shadow: 0 8px 28px rgba(0,0,0,.22); border-radius: 14px; border-color: rgba(160, 200, 210, .28); }
+.mission .why { color: var(--muted); }
+.mission .actions { margin-top: 4px; }
+
+/* Collapsible behavior for non-active phases */
+.mission.is-collapsed { display: none; }
+.mission.is-active { outline: 1px solid rgba(90, 170, 160, .35); }
+
+/* Minimal stepper */
+.stepper { display:flex; gap:8px; margin:10px 0 8px; align-items:center; }
+.stepper .step { min-width:40px; min-height:40px; border-radius:999px; border:1px solid var(--border); background:var(--card); color:var(--text); font-weight:800; box-shadow:0 2px 8px rgba(0,0,0,.16); }
+.stepper .step[aria-current="step"] { border-color:#2fb171; box-shadow:0 0 0 2px rgba(47,177,113,.2) inset; }
+.stepper .step:disabled { opacity:.5; }
+
+/* HUD subtle */
+.hud { margin-top: 8px; }
+
+/* Achievements collapsed by default uses native <details> */
+.achievements summary { cursor:pointer; }
+
+/* RTL consistency */
+html[dir="rtl"] .stepper { direction: rtl; }

--- a/assets/js/self-audit.js
+++ b/assets/js/self-audit.js
@@ -1,181 +1,176 @@
 (function(){
   const KEY = 'sra_self_audit_v1';
+  const COOKIE = 'sra_phase';
   const CONFIG = {
     xpPerQuest: 5,
     xpPhaseBonus: 20,
-    linear: false, // set to true to lock phases sequentially (D → A → R → K)
+    linear: true, // enforce D→A→R→K
+    order: ['D','A','R','K'],
+    cookieDays: 180,
   };
 
   const $ = (s, r=document)=>r.querySelector(s);
   const $$ = (s, r=document)=>Array.from(r.querySelectorAll(s));
 
+  // ----- state -----
   const state = load();
-  hydrate();
+  hydrateMeta();
   wireMissions();
+  wireStepper();
   recalcAll();
+  setActivePhase(getActivePhase());
 
-  // ------------ wiring ------------
+  // ----- wiring -----
   function wireMissions(){
     $$('.mission').forEach(m => {
       const phase = m.getAttribute('data-phase');
-      const prior = prevPhase(phase);
-
-      // Linear lock control
-      if (CONFIG.linear && prior && !state.phases[prior]) {
-        m.classList.add('is-locked');
-        $$('input,button,textarea,a', m).forEach(el => el.setAttribute('disabled',''));
-      } else {
-        m.classList.remove('is-locked');
-        $$('input,button,textarea,a', m).forEach(el => el.removeAttribute('disabled'));
-      }
 
       // Checkboxes
       $$('.quest input', m).forEach(cb => {
         cb.checked = !!state.quests[cb.dataset.quest];
-        cb.addEventListener('change', () => {
-          state.quests[cb.dataset.quest] = cb.checked;
-          persist();
-          recalcPhase(m, phase);
-          recalcAll();
-        });
+        cb.addEventListener('change', () => { state.quests[cb.dataset.quest] = cb.checked; persist(); recalcPhase(m, phase); recalcAll(); });
       });
 
-      // Note
+      // Notes
       const ta = $('.note', m);
-      if (ta){
-        ta.value = state.notes[phase] || '';
-        ta.addEventListener('input', ()=>{ state.notes[phase] = ta.value; persist(); stamp(); });
-      }
+      if (ta){ ta.value = state.notes[phase] || ''; ta.addEventListener('input', ()=>{ state.notes[phase] = ta.value; persist(); stamp(); }); }
 
       // Complete / Reset
       $('[data-complete]', m)?.addEventListener('click', ()=>{
-        state.phases[phase] = true;
-        persist();
-        recalcPhase(m, phase);
-        wireMissions(); // unlock next if linear
-        recalcAll();
+        state.phases[phase] = true; persist(); recalcPhase(m, phase); recalcAll();
+        // Advance to next phase automatically
+        const next = nextPhase(phase);
+        if (next) setActivePhase(next);
       });
       $('[data-reset]', m)?.addEventListener('click', ()=>{
-        resetPhase(phase, m);
-        wireMissions();
-        recalcAll();
+        resetPhase(phase, m); recalcAll(); setActivePhase(phase);
       });
 
       recalcPhase(m, phase);
     });
-
-    $('#resetAll')?.addEventListener('click', ()=>{ localStorage.removeItem(KEY); location.reload(); });
   }
 
-  // ------------ calculations ------------
+  function wireStepper(){
+    $$('.stepper .step').forEach(btn => {
+      btn.addEventListener('click', ()=>{
+        const p = btn.getAttribute('data-step');
+        if (isUnlocked(p)) setActivePhase(p);
+      });
+    });
+  }
+
+  // ----- active/linear control -----
+  function getActivePhase(){
+    const cookieP = readCookie(COOKIE);
+    if (cookieP && CONFIG.order.includes(cookieP)) return cookieP;
+    // first incomplete or last (K) if all done
+    for (const p of CONFIG.order){ if (!state.phases[p]) return p; }
+    return 'K';
+  }
+
+  function setActivePhase(phase){
+    // Lock/Unlock according to linear progression
+    CONFIG.order.forEach(p => {
+      const mission = `.mission[data-phase="${p}"]`;
+      const el = $(mission);
+      const unlocked = isUnlocked(p);
+      if (!el) return;
+      if (p === phase) {
+        el.classList.remove('is-locked');
+        el.classList.add('is-active');
+        el.classList.remove('is-collapsed');
+        el.style.display = '';
+      } else {
+        el.classList.toggle('is-locked', !unlocked);
+        el.classList.add('is-collapsed');
+        el.style.display = 'none';
+      }
+    });
+
+    // Stepper UI (aria + disabled)
+    $$('.stepper .step').forEach(btn => {
+      const p = btn.getAttribute('data-step');
+      const current = p === phase;
+      btn.setAttribute('aria-current', current ? 'step' : 'false');
+      btn.disabled = !isUnlocked(p);
+    });
+
+    // Save active phase
+    state.active = phase; persist(); writeCookie(COOKIE, phase, CONFIG.cookieDays);
+    // Focus the first focusable in the active mission for keyboard users
+    const first = $(`.mission[data-phase="${phase}"]`)?.querySelector('input,button,textarea,a');
+    first?.focus();
+  }
+
+  function isUnlocked(phase){
+    const idx = CONFIG.order.indexOf(phase);
+    if (idx <= 0) return true; // D is always unlocked
+    const prev = CONFIG.order[idx-1];
+    return !!state.phases[prev];
+  }
+  function nextPhase(phase){ const idx = CONFIG.order.indexOf(phase); return CONFIG.order[idx+1] || null; }
+
+  // ----- calculations/UI meta -----
   function recalcPhase(m, phase){
     const cbs = $$('.quest input', m);
     const done = cbs.filter(cb=>cb.checked).length;
     const total = cbs.length || 1;
     const pct = Math.round((done/total)*100);
-
-    const badge = $('[data-phase-xp]', m);
-    if (badge) badge.textContent = phase + ' ' + pct + '%';
-
-    // XP for this phase
-    const phaseXp = done * CONFIG.xpPerQuest + (state.phases[phase] ? CONFIG.xpPhaseBonus : 0);
+    const badge = $('[data-phase-xp]', m); if (badge) badge.textContent = phase + ' ' + pct + '%';
+    const phaseXp = done * 5 + (state.phases[phase] ? 20 : 0);
     m.setAttribute('data-xp', String(phaseXp));
-
-    // Phase header meter style
     m.style.setProperty('--phase-pct', pct + '%');
   }
 
   function recalcAll(){
-    // Overall progress
     const allCbs = $$('.quest input');
     const done = allCbs.filter(cb=>cb.checked).length;
     const total = allCbs.length || 1;
     const pct = Math.round((done/total)*100);
-    const fill = $('#overallFill');
-    if (fill) fill.style.width = pct + '%';
-    const pctEl = $('#overallPct');
-    if (pctEl) pctEl.textContent = pct + '%';
-
-    // XP total
-    const xp = sumXP();
-    const xpEl = $('#xpTotal');
-    if (xpEl) xpEl.textContent = xp;
-
-    // Threat meter label
-    const threat = threatLabel(pct);
-    const tl = $('#threatLabel');
-    if (tl) tl.textContent = threat;
-
-    // Achievements
+    $('#overallFill').style.width = pct + '%';
+    $('#overallPct').textContent = pct + '%';
+    $('#xpTotal')?.textContent = sumXP();
+    $('#threatLabel')?.textContent = threatLabel(pct);
     updateAchievements(pct);
-
-    // timestamp
     stamp();
   }
 
-  function sumXP(){
-    let xp = 0;
-    $$('.mission').forEach(m => { xp += Number(m.getAttribute('data-xp')||0); });
-    return xp;
-  }
-
-  function threatLabel(pct){
-    if (pct < 25) return 'Exposed';
-    if (pct < 70) return 'Hardening';
-    return 'Hardened';
-  }
+  function sumXP(){ let xp = 0; $$('.mission').forEach(m => { xp += Number(m.getAttribute('data-xp')||0); }); return xp; }
+  function threatLabel(pct){ if (pct < 25) return 'Exposed'; if (pct < 70) return 'Hardening'; return 'Hardened'; }
 
   function updateAchievements(pct){
     const a = state.ach || (state.ach = {});
-    const list = $('#achList');
-    if (!list) return;
-
-    function unlock(key, label){ if (!a[key]) { a[key] = true; pushAch(label); persist(); } }
-    function pushAch(label){ const li = document.createElement('li'); li.textContent = label; list.appendChild(li); }
-
-    // Clear and redraw current
+    const list = $('#achList'); if (!list) return;
+    function unlock(key, label){ if (!a[key]){ a[key] = true; push(label); persist(); } }
+    function push(label){ const li = document.createElement('li'); li.textContent = label; list.appendChild(li); }
     list.innerHTML = '';
-    Object.entries(a).forEach(([k,v])=>{ if (v) pushAch(labelFor(k)); });
-
-    // Check unlocks
+    Object.entries(a).forEach(([k,v])=>{ if (v) push(labelFor(k)); });
     if (sumXP() >= 10) unlock('first_steps','First Steps');
-    if (phaseDone('D')) unlock('discovery','Discovery Done');
-    if (phaseDone('A')) unlock('analyzer','Analyzer');
-    if (phaseDone('R')) unlock('reducer','Reducer');
-    if (phaseDone('K')) unlock('keeper','Keeper');
+    if (state.phases.D) unlock('discovery','Discovery Done');
+    if (state.phases.A) unlock('analyzer','Analyzer');
+    if (state.phases.R) unlock('reducer','Reducer');
+    if (state.phases.K) unlock('keeper','Keeper');
     if (pct === 100) unlock('perfect','100% Completion');
   }
+  function labelFor(k){ return ({first_steps:'First Steps', discovery:'Discovery Done', analyzer:'Analyzer', reducer:'Reducer', keeper:'Keeper', perfect:'100% Completion'})[k] || k; }
 
-  function phaseDone(p){ return !!state.phases[p]; }
-  function prevPhase(p){ return ({A:'D', R:'A', K:'R'})[p] || null; }
-
-  // ------------ persistence & meta ------------
+  // ----- persistence -----
   function load(){
-    try{ return JSON.parse(localStorage.getItem(KEY)) || { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null }; }
-    catch(e){ return { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null }; }
+    try{ return JSON.parse(localStorage.getItem(KEY)) || { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null, active:null }; }
+    catch(e){ return { quests:{}, notes:{}, phases:{D:false,A:false,R:false,K:false}, ach:{}, ts:null, active:null }; }
   }
   function persist(){ localStorage.setItem(KEY, JSON.stringify(state)); }
   function stamp(){ const el = document.getElementById('lastUpdated'); if (!el) return; const d = new Date(); state.ts = d.toISOString(); persist(); el.textContent = 'Last updated: ' + d.toLocaleString(); }
-  function hydrate(){ if (state.ts){ const d = new Date(state.ts); const el = document.getElementById('lastUpdated'); if (el) el.textContent = 'Last updated: ' + d.toLocaleString(); } }
+  function hydrateMeta(){ if (state.ts){ const d = new Date(state.ts); const el = document.getElementById('lastUpdated'); if (el) el.textContent = 'Last updated: ' + d.toLocaleString(); } }
 
-  // ------------ reset helpers ------------
+  // ----- cookies (privacy‑minimal: phase only) -----
+  function writeCookie(name, value, days){ const d = new Date(); d.setTime(d.getTime() + (days*24*60*60*1000)); document.cookie = name + '=' + encodeURIComponent(value) + ';expires=' + d.toUTCString() + ';path=/;SameSite=Lax'; }
+  function readCookie(name){ const ca = document.cookie.split(';'); const n = name + '='; for (let c of ca){ c = c.trim(); if (c.indexOf(n)===0) return decodeURIComponent(c.substring(n.length)); } return null; }
+
+  // ----- reset helpers -----
   function resetPhase(phase, m){
     $$('.quest input', m).forEach(cb => { cb.checked = false; delete state.quests[cb.dataset.quest]; });
     const ta = $('.note', m); if (ta){ ta.value = ''; delete state.notes[phase]; }
-    state.phases[phase] = false;
-    persist();
-    recalcPhase(m, phase);
-  }
-
-  function labelFor(key){
-    switch (key){
-      case 'first_steps': return 'First Steps';
-      case 'discovery': return 'Discovery Done';
-      case 'analyzer': return 'Analyzer';
-      case 'reducer': return 'Reducer';
-      case 'keeper': return 'Keeper';
-      case 'perfect': return '100% Completion';
-      default: return key;
-    }
+    state.phases[phase] = false; persist(); recalcPhase(m, phase);
   }
 })();

--- a/self-audit.html
+++ b/self-audit.html
@@ -70,9 +70,16 @@
       <div class="hud-item"><span class="label">Threat</span><span id="threatLabel" class="value">Exposed</span></div>
     </section>
 
+    <section class="stepper" aria-label="Progress steps">
+      <button class="step" data-step="D" aria-current="false">D</button>
+      <button class="step" data-step="A" aria-current="false" disabled>A</button>
+      <button class="step" data-step="R" aria-current="false" disabled>R</button>
+      <button class="step" data-step="K" aria-current="false" disabled>K</button>
+    </section>
+
     <!-- Overview Cards -->
-    <section class="missions" aria-label="DARK missions">
-      <article class="mission" data-phase="D">
+    <section class="missions wizard" aria-label="DARK missions">
+      <article class="mission collapsible" data-phase="D">
         <span class="kicker">Phase 1</span>
         <h2>🕵️‍♂️ Discover — Hunt for clues</h2>
         <p class="why">This is your collection phase. Find out what exists about you online — posts, photos, mentions, tags, accounts, leaks.</p>
@@ -91,7 +98,7 @@
         </div>
       </article>
 
-      <article class="mission" data-phase="A">
+      <article class="mission collapsible" data-phase="A">
         <span class="kicker">Phase 2</span>
         <h2>🧠 Analyze — Think like an attacker</h2>
         <p class="why">Turn data into a threat map. Who could use it, how, and why?</p>
@@ -109,7 +116,7 @@
         </div>
       </article>
 
-      <article class="mission" data-phase="R">
+      <article class="mission collapsible" data-phase="R">
         <span class="kicker">Phase 3</span>
         <h2>🛠️ Reduce — Shrink your exposure</h2>
         <p class="why">Decide what stays, what goes, and what changes. Make a plan — don’t execute everything yet.</p>
@@ -127,7 +134,7 @@
         </div>
       </article>
 
-      <article class="mission" data-phase="K">
+      <article class="mission collapsible" data-phase="K">
         <span class="kicker">Phase 4</span>
         <h2>🔐 Keep Safe — Make it a habit</h2>
         <p class="why">Implement your plan and keep it alive over time.</p>
@@ -151,10 +158,10 @@
       <span class="pill" id="lastUpdated">Last updated: —</span>
     </section>
 
-    <section class="prose achievements" aria-labelledby="achTitle">
-      <h2 id="achTitle">Achievements</h2>
+    <details class="prose achievements" aria-labelledby="achTitle">
+      <summary><h2 id="achTitle">Achievements</h2></summary>
       <ul id="achList" class="ach-list"></ul>
-    </section>
+    </details>
   </main>
 
   <!-- Ethics pledge modal (unchanged ids for existing JS) -->


### PR DESCRIPTION
## Summary
- add a DARK stepper and linear mission locking to guide the self-audit flow
- persist quests, notes, and active phase across sessions via localStorage and cookies
- refresh mission layout and collapse achievements for a calmer presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a0dcc7a083238fd922b1e4c1ddbb