### PR TITLE
Register service worker with base path awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Serve the repo root with any static server to preview:
 python -m http.server 8000
 ```
 
-Then open [http://localhost:8000/index.html](http://localhost:8000/index.html). The service worker registers automatically on load.
+Then open [http://localhost:8000/index.html](http://localhost:8000/index.html). The service worker registers automatically on load and
+resolves the correct scope for both local preview and the GitHub Pages `/PRIVACY/` base path. Registration successes and failures are
+logged to the console for troubleshooting. The “Install App” button stays disabled until the browser fires `beforeinstallprompt`, at which
+point it becomes interactive.
 
 To verify the offline shell:
 

--- a/assets/js/install.js
+++ b/assets/js/install.js
@@ -10,17 +10,23 @@
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e;
-    if (installBtn) installBtn.disabled = false;
+    if (installBtn) {
+      installBtn.disabled = false;
+      installBtn.setAttribute('aria-disabled', 'false');
+      console.debug('[pwa] beforeinstallprompt fired');
+    }
   });
 
   if (installBtn) {
     installBtn.disabled = true;
+    installBtn.setAttribute('aria-disabled', 'true');
     installBtn.addEventListener('click', async () => {
       if (!deferredPrompt) return;
       deferredPrompt.prompt();
       await deferredPrompt.userChoice;
       deferredPrompt = null;
       installBtn.disabled = true;
+      installBtn.setAttribute('aria-disabled', 'true');
     });
   }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -74,3 +74,38 @@
     overlay.addEventListener('click', closeMenu);
   }
 })();
+
+/* Service worker bootstrap: register once the page is ready and log outcomes */
+(function(){
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const scriptEl = document.currentScript || Array.from(document.querySelectorAll('script')).find(s => (s.src || '').includes('/assets/js/main.js'));
+  let swPath = '/sw.js';
+
+  if (scriptEl && scriptEl.src) {
+    try {
+      const scriptUrl = new URL(scriptEl.src, window.location.href);
+      const basePath = scriptUrl.pathname.replace(/assets\/js\/main\.js$/, '');
+      if (basePath) swPath = `${basePath}sw.js`;
+    } catch (error) {
+      console.error('[pwa] Failed to resolve service worker path', error);
+    }
+  }
+
+  const register = async () => {
+    try {
+      const registration = await navigator.serviceWorker.register(swPath);
+      console.debug('[pwa] Service worker registered', registration.scope);
+    } catch (error) {
+      console.error('[pwa] Service worker registration failed', error);
+    }
+  };
+
+  if (document.readyState === 'complete') {
+    register();
+  } else {
+    window.addEventListener('load', register, { once: true });
+  }
+})();


### PR DESCRIPTION
## Summary
- register the service worker after the window load event and derive the GitHub Pages base path from the script URL
- add diagnostics and aria-disabled toggling around the Install App button so it re-enables when beforeinstallprompt fires
- document the registration behavior and install button gating in the README

## Testing
- npm test *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39a3547388323863b87275d490925