### PR TITLE
Add Instagram privacy guides batch one

### DIFF
--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -62,8 +62,8 @@
 <h3>Mobile (Instagram app)</h3>
 <ul>
 <li><strong>Profile tab:</strong> Bottom-right circle icon. Tap it to open your profile.</li>
-<li><strong>Menu (☰):</strong> Top-right of your profile. Tap to open <strong>Settings and privacy</strong>.</li>
-<li><strong>Accounts Center:</strong> Lives at the top of <strong>Settings and privacy</strong>. Use it for password, login, and cross-app controls.</li>
+<li><strong>Menu (☰):</strong> Top-right of your profile. Tap to open <strong>Settings &amp; privacy</strong>.</li>
+<li><strong>Accounts Center:</strong> Lives at the top of <strong>Settings &amp; privacy</strong>. Use it for password, login, and cross-app controls.</li>
 <li><strong>Search bar:</strong> Within Settings, use the search field at the top to find features quickly.</li>
 </ul>
 <h3>Desktop (instagram.com)</h3>
@@ -78,257 +78,1151 @@
 <nav aria-label="Guides" class="card" id="guide-index">
 <h2>Guides</h2>
 <ol>
-<li class="guide-range-divider"><span>Guides #1–12</span></li>
-<li><a href="#guide-change-your-instagram-password">Change Your Instagram Password</a></li>
-<li><a href="#guide-enable-instagram-two-factor-authentication">Enable Instagram Two-Factor Authentication</a></li>
-<li><a href="#guide-save-instagram-backup-codes">Save Instagram Backup Codes</a></li>
-<li><a href="#guide-review-instagram-login-activity">Review Instagram Login Activity</a></li>
-<li><a href="#guide-update-instagram-recovery-info">Update Instagram Recovery Info</a></li>
-<li><a href="#guide-make-instagram-account-private">Make Your Instagram Account Private</a></li>
-<li><a href="#guide-limit-who-can-reply-to-your-stories">Limit Who Can Reply to Your Stories</a></li>
-<li><a href="#guide-control-instagram-message-requests">Control Instagram Message Requests</a></li>
-<li><a href="#guide-hide-instagram-activity-status">Hide Your Instagram Activity Status</a></li>
-<li><a href="#guide-remove-connected-apps-on-instagram">Remove Connected Apps on Instagram</a></li>
-<li><a href="#guide-adjust-instagram-ad-topics">Adjust Instagram Ad Topics</a></li>
-<li><a href="#guide-download-your-instagram-data">Download Your Instagram Data</a></li>
+<li class="guide-range-divider"><span>Guides #1–15</span></li>
+<li><a href="#guide-enable-two-factor-authentication-2fa">Enable Two-Factor Authentication (2FA)</a></li>
+<li><a href="#guide-turn-on-login-alerts">Turn On Login Alerts &amp; Review Security Emails</a></li>
+<li><a href="#guide-review-login-activity-log-out">Review Login Activity &amp; Log Out of Unknown Devices</a></li>
+<li><a href="#guide-change-password-enable-password-manager">Change Password &amp; Enable Password Manager</a></li>
+<li><a href="#guide-set-up-backup-codes-offline">Set Up Backup Codes (Offline)</a></li>
+<li><a href="#guide-verify-email-phone-remove-old-recovery-info">Verify Email &amp; Phone, Remove Old Recovery Info</a></li>
+<li><a href="#guide-set-account-to-private">Set Account to Private</a></li>
+<li><a href="#guide-hide-activity-status">Hide Activity Status</a></li>
+<li><a href="#guide-restrict-who-can-mention-you">Restrict Who Can Mention You</a></li>
+<li><a href="#guide-control-who-can-tag-you">Control Who Can Tag You in Photos &amp; Videos</a></li>
+<li><a href="#guide-filter-comments-hidden-words">Filter Comments (Hidden Words &amp; Offensive Filters)</a></li>
+<li><a href="#guide-limit-who-can-reply-to-your-posts">Limit Who Can Reply to Your Posts</a></li>
+<li><a href="#guide-story-audience-and-reply-controls">Story Audience &amp; Reply Controls</a></li>
+<li><a href="#guide-prevent-sharing-your-stories-and-posts">Prevent Others from Sharing Your Stories &amp; Posts</a></li>
+<li><a href="#guide-control-reels-remix-and-downloading">Control Reels Remix &amp; Downloading</a></li>
+<li class="guide-range-divider"><span>Guides #16–30</span></li>
+<li><a href="#guide-sensitive-content-control">Sensitive Content Control (Explore/Reels/Recommendations)</a></li>
+<li><a href="#guide-hide-like-and-view-counts">Hide Like &amp; View Counts</a></li>
+<li><a href="#guide-message-controls-who-can-message-you">Message Controls (Who Can Message You)</a></li>
+<li><a href="#guide-restrict-mute-or-block-problem-accounts">Restrict, Mute, or Block Problem Accounts</a></li>
+<li><a href="#guide-review-third-party-apps-websites">Review Third-Party Apps/Websites Connected to Instagram</a></li>
+<li><a href="#guide-ad-preferences-and-topics">Ad Preferences &amp; Topics (Meta Accounts Center)</a></li>
+<li><a href="#guide-off-meta-activity">Off-Meta Activity (Limit Data From Partners)</a></li>
+<li><a href="#guide-close-friends-list">Close Friends List (Stories)</a></li>
+<li><a href="#guide-hide-your-profile-from-contacts">Hide Your Profile From Contacts/Discoverability</a></li>
+<li><a href="#guide-manage-comment-controls-per-post">Manage Comment Controls Per Post</a></li>
+<li><a href="#guide-delete-face-tag-suggestions">Delete Face/Tag Suggestions on Old Posts</a></li>
+<li><a href="#guide-limit-story-replies-to-close-friends">Limit Story Replies to Close Friends Only</a></li>
+<li><a href="#guide-quiet-mode-notification-controls">Quiet Mode / Notification Controls</a></li>
+<li><a href="#guide-download-your-information-export">Download Your Information (Export)</a></li>
+<li><a href="#guide-delete-search-history-and-suggested-results">Delete Search History &amp; Suggested Results</a></li>
 </ol>
 </nav>
-<h2 class="guide-range-heading" id="range-1-12">Guides #1–12</h2>
-<section class="card" id="guide-change-your-instagram-password">
-<h2>Change Your Instagram Password</h2>
-<details open="">
-<summary>On Mobile</summary>
+<h2 class="guide-range-heading" id="range-1-15">Guides #1–15</h2>
+<section class="card" id="guide-enable-two-factor-authentication-2fa">
+<h3>Enable Two-Factor Authentication (2FA)</h3>
+<p class="lead"><strong>Why this matters:</strong> 2FA stops most account takeovers even if your password leaks.</p>
+<p><strong>What you’ll change:</strong> Turn on 2FA (prefer an authenticator or passkey) and store backup codes.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Open the <strong>Instagram app</strong> and tap your <strong>profile</strong> (bottom-right).</li>
-<li>Tap the <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li>Choose <strong>Password and security</strong> → <strong>Change password</strong>.</li>
-<li>Select your Instagram account, enter your current password, set a new strong password, then tap <strong>Save</strong>.</li>
+<li>Go to your <strong>profile</strong> on <strong>instagram.com</strong> and click the <strong>Menu (☰)</strong>.</li>
+<li>Select <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Choose <strong>Two-factor authentication</strong> → pick <strong>Authentication app</strong> (recommended) → follow the code setup.</li>
+<li>Open <strong>Backup codes</strong>, copy the list, and save it offline (paper or secure password manager note).</li>
+<li>If menus shift, use the settings search bar and type <strong>"Two-factor"</strong>.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On Android</summary>
 <ol>
-<li>Visit <strong>instagram.com</strong>, sign in, then click <strong>More</strong> (left sidebar) → <strong>Settings</strong>.</li>
-<li>Select <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Change password</strong>.</li>
-<li>Enter your current password and a new unique password, then choose <strong>Save</strong>.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Use at least 12 characters and avoid reusing passwords from other services.</p>
-</section>
-<section class="card" id="guide-enable-instagram-two-factor-authentication">
-<h2>Enable Instagram Two-Factor Authentication</h2>
-<details open="">
-<summary>On Mobile</summary>
-<ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li>Select <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
-<li>Choose <strong>Authentication app</strong> or <strong>Security key</strong>, follow the setup prompts, then tap <strong>Turn on</strong>.</li>
+<li>Open Instagram → tap your <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Enter the <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
+<li>Select <strong>Authentication app</strong> or <strong>Passkey</strong>, complete setup, and confirm.</li>
+<li>Back in 2FA, tap <strong>Backup codes</strong> → <strong>Get new codes</strong> → store them offline.</li>
+<li>Search for <strong>"two-factor"</strong> in Settings if the menu order differs.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Accounts Center</strong>.</li>
-<li><strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
-<li>Pick your preferred method (authenticator app or security key) and complete the flow.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
+<li>Choose <strong>Authentication app</strong> or <strong>Passkey</strong>, finish the pairing, then toggle on.</li>
+<li>Tap <strong>Backup codes</strong> → <strong>Get new codes</strong> → record them securely offline.</li>
+<li>If needed, use Settings search for <strong>"Two-factor"</strong> to jump to the feature.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Authenticator apps or security keys are more resistant to phishing than SMS codes.</p>
+<p><em>Notes: Avoid SMS codes unless it’s the only option; authenticator apps or passkeys resist phishing.</em></p>
+<p><strong>Related terms:</strong> 2FA, MFA, OTP, backup codes, passkeys.</p>
 </section>
-<section class="card" id="guide-save-instagram-backup-codes">
-<h2>Save Instagram Backup Codes</h2>
-<details open="">
-<summary>On Mobile</summary>
+<section class="card" id="guide-turn-on-login-alerts">
+<h3>Turn On Login Alerts &amp; Review Security Emails</h3>
+<p class="lead"><strong>Why this matters:</strong> Immediate alerts for suspicious logins let you lock things down quickly.</p>
+<p><strong>What you’ll change:</strong> Enable login alerts and confirm your official security email list.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Visit <strong>instagram.com</strong> → profile → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Choose <strong>Security</strong> or <strong>Password and security</strong> → <strong>Emails from Instagram</strong>.</li>
+<li>Review the list of security emails sent in the past 14 days so you know what’s legitimate.</li>
+<li>If you see <strong>Login alerts</strong>, turn on email and push notifications for unrecognized logins.</li>
+<li>Search Settings for <strong>"Emails from Instagram"</strong> if you don’t spot the menu immediately.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Notifications</strong> → <strong>Security</strong>.</li>
+<li>Enable alerts for <strong>Suspicious login attempts</strong> (email and push).</li>
+<li>Go back → under <strong>Security</strong>, open <strong>Emails from Instagram</strong> to confirm official messages.</li>
+<li>Use the Settings search for <strong>"Security emails"</strong> if options moved.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Open Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Select <strong>Notifications</strong> → <strong>Security</strong>.</li>
+<li>Toggle on alerts for unrecognized logins or suspicious login attempts.</li>
+<li>Under <strong>Security</strong>, tap <strong>Emails from Instagram</strong> to verify recent official communications.</li>
+<li>Search Settings for <strong>"Login alerts"</strong> if the navigation differs.</li>
+</ol>
+</details>
+<p><em>Notes: Only trust emails listed in <strong>Emails from Instagram</strong>; anything else could be phishing.</em></p>
+<p><strong>Related terms:</strong> suspicious login, security notifications, phishing.</p>
+</section>
+<section class="card" id="guide-review-login-activity-log-out">
+<h3>Review Login Activity &amp; Log Out of Unknown Devices</h3>
+<p class="lead"><strong>Why this matters:</strong> Unknown sessions can persist for months.</p>
+<p><strong>What you’ll change:</strong> Check active sessions and sign out everywhere you don’t recognize.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>From your profile menu on <strong>instagram.com</strong>, open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Go to <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Click <strong>See all</strong> to expand the full device list.</li>
+<li>Select unfamiliar sessions and choose <strong>Log out</strong>.</li>
+<li>Use the settings search for <strong>"Where you're logged in"</strong> if the link has moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Hit <strong>See all</strong>, inspect each device, and tap <strong>Log out</strong> for anything suspicious.</li>
+<li>After removing unknown sessions, change your password if needed.</li>
+<li>Search for <strong>"logged in"</strong> if you can’t find the page.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Review the list, tapping <strong>See all</strong> to reveal older devices.</li>
+<li>Remove unknown sessions with <strong>Log out</strong>, then reset your password if anything looks off.</li>
+<li>Use Settings search for <strong>"Where you’re logged in"</strong> if layout changed.</li>
+</ol>
+</details>
+<p><em>Notes: If you find unknown access, also check your recovery email and phone for compromise.</em></p>
+<p><strong>Related terms:</strong> device sessions, session hijack.</p>
+</section>
+<section class="card" id="guide-change-password-enable-password-manager">
+<h3>Change Password &amp; Enable Password Manager</h3>
+<p class="lead"><strong>Why this matters:</strong> Strong, unique passwords reduce breach impact.</p>
+<p><strong>What you’ll change:</strong> Set a long, unique password and save it in a manager.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Profile → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Select <strong>Password and security</strong> → <strong>Change password</strong>.</li>
+<li>Create a new password with at least 12 characters, mixing words, numbers, and symbols.</li>
+<li>Save it in your browser or dedicated password manager when prompted.</li>
+<li>Search for <strong>"Change password"</strong> if the option isn’t visible.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Password and security</strong> → <strong>Change password</strong>.</li>
+<li>Enter your current password, then set a unique new one.</li>
+<li>Allow Google Password Manager to save the update when prompted.</li>
+<li>Use the Settings search for <strong>"password"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Change password</strong>.</li>
+<li>Enter a strong new password and confirm it.</li>
+<li>Save it in iCloud Keychain or your preferred password manager.</li>
+<li>Search for <strong>"password"</strong> in Settings if menus move.</li>
+</ol>
+</details>
+<p><em>Notes: Never reuse your email password; keeping them unique prevents credential stuffing.</em></p>
+<p><strong>Related terms:</strong> credential stuffing, brute force.</p>
+</section>
+<section class="card" id="guide-set-up-backup-codes-offline">
+<h3>Set Up Backup Codes (Offline)</h3>
+<p class="lead"><strong>Why this matters:</strong> If you lose your phone, backup codes can save you.</p>
+<p><strong>What you’ll change:</strong> Generate and securely store single-use codes.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Profile → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Go to <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
+<li>Open <strong>Backup codes</strong> → <strong>Get new codes</strong>.</li>
+<li>Download, copy, or print the codes and store them offline (not in screenshots on shared devices).</li>
+<li>Search for <strong>"Backup codes"</strong> if the navigation has changed.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Password and security</strong> → <strong>Two-factor authentication</strong> → <strong>Backup codes</strong>.</li>
-<li>Generate a new set, then copy or screenshot the codes and store them securely offline.</li>
+<li>Choose <strong>Get new codes</strong> and save them in a secure offline place.</li>
+<li>Consider copying them into an encrypted password manager note.</li>
+<li>Use Settings search for <strong>"Backup"</strong> if menus differ.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li>From <strong>instagram.com</strong>, open <strong>More</strong> → <strong>Settings</strong> → <strong>Accounts Center</strong>.</li>
-<li>Choose <strong>Password and security</strong> → <strong>Two-factor authentication</strong> → <strong>Backup codes</strong>.</li>
-<li>Download or print the codes and keep them in a safe place.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Enter <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
+<li>Tap <strong>Backup codes</strong> → <strong>Get new codes</strong> and copy them somewhere offline.</li>
+<li>Store the codes in a secure note or physical safe.</li>
+<li>Search for <strong>"Backup codes"</strong> via Settings if the path looks different.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Use backup codes when you do not have your phone or authenticator app available.</p>
+<p><em>Notes: Treat codes like keys—keep them offline and rotate after using one.</em></p>
+<p><strong>Related terms:</strong> recovery codes, offline access.</p>
 </section>
-<section class="card" id="guide-review-instagram-login-activity">
-<h2>Review Instagram Login Activity</h2>
-<details open="">
-<summary>On Mobile</summary>
+<section class="card" id="guide-verify-email-phone-remove-old-recovery-info">
+<h3>Verify Email &amp; Phone, Remove Old Recovery Info</h3>
+<p class="lead"><strong>Why this matters:</strong> Attackers often pivot via weak recovery channels.</p>
+<p><strong>What you’ll change:</strong> Confirm your current email/phone and delete outdated numbers or addresses.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li>Select <strong>Password and security</strong> → <strong>Where you're logged in</strong>.</li>
-<li>Review each device; tap any unfamiliar session → <strong>Log out</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>On Desktop</summary>
-<ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Accounts Center</strong>.</li>
-<li>Open <strong>Password and security</strong> → <strong>Where you're logged in</strong>.</li>
-<li>Click <strong>Log out</strong> next to devices you do not recognize.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Check this after travel or using public computers to catch unwanted access quickly.</p>
-</section>
-<section class="card" id="guide-update-instagram-recovery-info">
-<h2>Update Instagram Recovery Info</h2>
-<details open="">
-<summary>On Mobile</summary>
-<ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li>Tap <strong>Personal details</strong> → <strong>Contact info</strong>.</li>
-<li>Add a recovery email and phone, verify them, then adjust visibility to <strong>Only me</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>On Desktop</summary>
-<ol>
-<li>Open <strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Accounts Center</strong>.</li>
+<li>On <strong>instagram.com</strong>, open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Choose <strong>Personal details</strong> → <strong>Contact info</strong>.</li>
-<li>Confirm your recovery contacts and hide them from your public profile.</li>
+<li>Add or verify your current email and mobile number, removing any outdated entries.</li>
+<li>Check verification emails or texts to confirm ownership.</li>
+<li>Use Settings search for <strong>"Personal details"</strong> if needed.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> A private, up-to-date recovery email helps you regain access if your account is locked.</p>
-</section>
-<section class="card" id="guide-make-instagram-account-private">
-<h2>Make Your Instagram Account Private</h2>
-<details open="">
-<summary>On Mobile</summary>
+<details>
+<summary>On Android</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Edit profile</strong>.</li>
+<li>Tap <strong>Personal information</strong> (or go through <strong>Accounts Center</strong> → <strong>Personal details</strong>).</li>
+<li>Update your email and phone, verify them, and delete any old contact points.</li>
+<li>Ensure the recovery email you use has its own 2FA enabled.</li>
+<li>Search Settings for <strong>"Contact info"</strong> if the path has changed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Edit profile</strong> → <strong>Personal information</strong>.</li>
+<li>Update your email and phone, then tap to verify via confirmation links or codes.</li>
+<li>Remove any phone numbers or addresses you no longer control.</li>
+<li>Double-check linked emails also use strong passwords and 2FA.</li>
+<li>Search for <strong>"Contact"</strong> in Settings if the option is hidden.</li>
+</ol>
+</details>
+<p><em>Notes: Use a recovery email that’s private and secured with its own 2FA.</em></p>
+<p><strong>Related terms:</strong> account recovery, takeover prevention.</p>
+</section>
+<section class="card" id="guide-set-account-to-private">
+<h3>Set Account to Private</h3>
+<p class="lead"><strong>Why this matters:</strong> Limits who can see your posts and followers.</p>
+<p><strong>What you’ll change:</strong> Switch your account to <strong>Private</strong>.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>From your profile on <strong>instagram.com</strong>, click <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Go to <strong>Privacy and safety</strong> or <strong>Privacy</strong>.</li>
+<li>Select <strong>Account privacy</strong> → toggle <strong>Private account</strong> on.</li>
+<li>Confirm the change when prompted.</li>
+<li>Search for <strong>"Private account"</strong> if the menu differs.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
 <li>Under <strong>Who can see your content</strong>, tap <strong>Account privacy</strong>.</li>
 <li>Toggle <strong>Private account</strong> on and confirm.</li>
+<li>Review your follower list afterward to remove any you don’t trust.</li>
+<li>Use Settings search for <strong>"Private"</strong> if the option moved.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li>Go to <strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong>.</li>
-<li>Select <strong>Privacy</strong> in the left column.</li>
-<li>Check <strong>Private account</strong> and confirm the change.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Account privacy</strong>.</li>
+<li>Turn on <strong>Private account</strong> and confirm.</li>
+<li>Periodically audit existing followers since they keep access.</li>
+<li>Search for <strong>"Account privacy"</strong> if layout has changed.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Only approved followers will see your posts, stories, and followers list.</p>
+<p><em>Notes: Existing followers remain—review them and remove anyone you don’t recognize.</em></p>
+<p><strong>Related terms:</strong> followers, public profile.</p>
 </section>
-<section class="card" id="guide-limit-who-can-reply-to-your-stories">
-<h2>Limit Who Can Reply to Your Stories</h2>
-<details open="">
-<summary>On Mobile</summary>
+<section class="card" id="guide-hide-activity-status">
+<h3>Hide Activity Status</h3>
+<p class="lead"><strong>Why this matters:</strong> Prevents others from seeing when you’re active.</p>
+<p><strong>What you’ll change:</strong> Turn off <strong>Activity status</strong> and <strong>Show when you’re active together</strong>.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Messages and story replies</strong>.</li>
-<li>Tap <strong>Story replies</strong>.</li>
-<li>Choose <strong>People you follow</strong> or <strong>Off</strong> to restrict replies.</li>
+<li>Open <strong>Settings &amp; privacy</strong> on <strong>instagram.com</strong> → <strong>Privacy</strong>.</li>
+<li>Choose <strong>Messages and story replies</strong> or <strong>Activity status</strong>.</li>
+<li>Toggle off <strong>Show activity status</strong> and any related “active together” options.</li>
+<li>Save changes if prompted.</li>
+<li>Search for <strong>"Activity status"</strong> if you can’t find the menu.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On Android</summary>
 <ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Privacy</strong>.</li>
-<li>Select <strong>Messages and story replies</strong> → <strong>Story replies</strong>.</li>
-<li>Pick who can reply to your stories.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Limiting replies reduces unwanted DMs triggered by stories.</p>
-</section>
-<section class="card" id="guide-control-instagram-message-requests">
-<h2>Control Instagram Message Requests</h2>
-<details open="">
-<summary>On Mobile</summary>
-<ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Messages and story replies</strong>.</li>
-<li>Tap <strong>Message controls</strong>.</li>
-<li>Adjust <strong>Potential connections</strong> and <strong>Others on Instagram</strong> to send requests to the <strong>Don't receive requests</strong> folder or turn them off entirely.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Privacy</strong> → <strong>Activity status</strong>.</li>
+<li>Turn off <strong>Show activity status</strong> and <strong>Show when you’re active together</strong>.</li>
+<li>Back out to save automatically.</li>
+<li>Search for <strong>"Activity status"</strong> if needed.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li>In <strong>Settings</strong>, choose <strong>Privacy</strong> → <strong>Messages</strong>.</li>
-<li>Set each category (People you follow, Others, Facebook friends) to the strictest option available.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Select <strong>Activity status</strong>.</li>
+<li>Disable both toggles for sharing activity.</li>
+<li>Exit to save.</li>
+<li>Use Settings search for <strong>"Activity"</strong> if layout differs.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Tight message controls limit spam and reduce phishing attempts in your inbox.</p>
+<p><em>Notes: You also won’t see others’ activity once disabled.</em></p>
+<p><strong>Related terms:</strong> last active, online status.</p>
 </section>
-<section class="card" id="guide-hide-instagram-activity-status">
-<h2>Hide Your Instagram Activity Status</h2>
-<details open="">
-<summary>On Mobile</summary>
+<section class="card" id="guide-restrict-who-can-mention-you">
+<h3>Restrict Who Can Mention You</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces harassment and drive-by tagging.</p>
+<p><strong>What you’ll change:</strong> Limit who can @mention your account.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Messages and story replies</strong>.</li>
-<li>Tap <strong>Show activity status</strong> and toggle it off.</li>
+<li>In <strong>Settings &amp; privacy</strong>, select <strong>Privacy</strong> → <strong>Mentions</strong>.</li>
+<li>Choose <strong>People you follow</strong> or <strong>No one</strong> to restrict mentions.</li>
+<li>Confirm the change.</li>
+<li>Review any pending mention requests if available.</li>
+<li>Search for <strong>"Mentions"</strong> if the option isn’t visible.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On Android</summary>
 <ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong>.</li>
-<li>Choose <strong>Privacy</strong> → <strong>Messages</strong> → toggle off <strong>Show activity status</strong>.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Hiding activity status prevents contacts from seeing when you were last active.</p>
-</section>
-<section class="card" id="guide-remove-connected-apps-on-instagram">
-<h2>Remove Connected Apps on Instagram</h2>
-<details open="">
-<summary>On Mobile</summary>
-<ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
-<li>Scroll to <strong>How others can interact with you</strong> and tap <strong>Apps and websites</strong>.</li>
-<li>Review <strong>Active</strong> apps, tap any you do not use, then tap <strong>Remove</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Mentions</strong>.</li>
+<li>Select <strong>People you follow</strong> or <strong>No one</strong>.</li>
+<li>Use the check mark to confirm if prompted.</li>
+<li>Search Settings for <strong>"mention"</strong> if menus move.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Apps and websites</strong>.</li>
-<li>Check the <strong>Active</strong> tab, click <strong>Remove</strong> for apps you do not trust.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open <strong>Privacy</strong> → <strong>Mentions</strong>.</li>
+<li>Choose <strong>People you follow</strong> or <strong>No one</strong> to limit tags.</li>
+<li>Exit to save automatically.</li>
+<li>Search for <strong>"Mentions"</strong> if it’s hidden.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Removing old integrations stops them from accessing your profile data.</p>
+<p><em>Notes: Pair with <strong>Tags</strong> controls for complete mention and tagging protection.</em></p>
+<p><strong>Related terms:</strong> tagging, anti-harassment.</p>
 </section>
-<section class="card" id="guide-adjust-instagram-ad-topics">
-<h2>Adjust Instagram Ad Topics</h2>
-<details open="">
-<summary>On Mobile</summary>
+<section class="card" id="guide-control-who-can-tag-you">
+<h3>Control Who Can Tag You in Photos &amp; Videos</h3>
+<p class="lead"><strong>Why this matters:</strong> Prevents unwanted profile associations.</p>
+<p><strong>What you’ll change:</strong> Require approval for new tags or block them entirely.</p>
+<details open>
+<summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Ads</strong>.</li>
-<li>Tap <strong>Ad topics</strong>.</li>
-<li>Choose sensitive topics and select <strong>See less</strong>.</li>
+<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li>Enable <strong>Manually approve tags</strong>.</li>
+<li>Review the <strong>Tagged posts</strong> queue and approve or decline pending tags.</li>
+<li>Remove yourself from any unwanted tags already attached.</li>
+<li>Search for <strong>"Tags"</strong> if the menu moved.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On Android</summary>
 <ol>
-<li>In <strong>Settings</strong>, select <strong>Ads</strong> → <strong>Ad topics</strong>.</li>
-<li>Set each topic you want to limit to <strong>See less</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Tags</strong>.</li>
+<li>Toggle <strong>Manually approve tags</strong> on, then review pending tagged posts.</li>
+<li>Use <strong>Remove me from post</strong> on any unwanted tag.</li>
+<li>Search for <strong>"Tags"</strong> in Settings if the option is hidden.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Adjusting ad topics reduces targeting based on sensitive interests.</p>
-</section>
-<section class="card" id="guide-download-your-instagram-data">
-<h2>Download Your Instagram Data</h2>
-<details open="">
-<summary>On Mobile</summary>
+<details>
+<summary>On iOS</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Select <strong>Tags</strong>.</li>
+<li>Enable <strong>Manually approve tags</strong> and review the pending list.</li>
+<li>Remove yourself from existing tags you don’t want.</li>
+<li>Use the search bar for <strong>"Tags"</strong> if navigation changed.</li>
+</ol>
+</details>
+<p><em>Notes: Approving tags manually stops automatic profile attachments.</em></p>
+<p><strong>Related terms:</strong> tag review, manual approval.</p>
+</section>
+<section class="card" id="guide-filter-comments-hidden-words">
+<h3>Filter Comments (Hidden Words &amp; Offensive Filters)</h3>
+<p class="lead"><strong>Why this matters:</strong> Cuts abusive comments and spam.</p>
+<p><strong>What you’ll change:</strong> Turn on Instagram’s filters and add custom keywords.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Within <strong>Settings &amp; privacy</strong>, choose <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Toggle on <strong>Hide comments</strong> and <strong>Advanced comment filtering</strong> (language may vary).</li>
+<li>Enable filters for <strong>Messages</strong> if available.</li>
+<li>Add custom words, phrases, or emojis in <strong>Custom words and phrases</strong> and apply them to comments and message requests.</li>
+<li>Search for <strong>"Hidden words"</strong> if menu placement changes.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Hidden words</strong>.</li>
+<li>Enable <strong>Offensive words and phrases</strong> and <strong>Advanced comment filtering</strong>.</li>
+<li>Under <strong>Custom words and phrases</strong>, add your keyword list and apply it to both comments and message requests.</li>
+<li>Use Settings search for <strong>"Hidden"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Activate built-in filters for offensive content and spam.</li>
+<li>Add your own blocked keywords and apply them to comments and DM requests.</li>
+<li>Search <strong>"Hidden words"</strong> if the option is hard to find.</li>
+</ol>
+</details>
+<p><em>Notes: Update your keyword list regularly and include variations, symbols, and emojis.</em></p>
+<p><strong>Related terms:</strong> comment moderation, toxicity.</p>
+</section>
+<section class="card" id="guide-limit-who-can-reply-to-your-posts">
+<h3>Limit Who Can Reply to Your Posts</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces pile-ons and unwanted replies.</p>
+<p><strong>What you’ll change:</strong> Set default reply controls for new posts or adjust per post.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>When creating a post, click <strong>Advanced settings</strong>.</li>
+<li>Select who can comment (Everyone, People you follow, or No one).</li>
+<li>After publishing, open the post → <strong>…</strong> → <strong>Who can comment</strong> to adjust if needed.</li>
+<li>For existing posts, repeat the <strong>…</strong> menu step to change comment access.</li>
+<li>Search for <strong>"Who can comment"</strong> in settings if you want to set defaults globally.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Create a post → scroll to <strong>Advanced settings</strong> → <strong>Who can comment</strong>.</li>
+<li>Pick <strong>People you follow</strong>, <strong>Followers you follow back</strong>, or <strong>Off</strong>.</li>
+<li>To update after posting, open the post → <strong>…</strong> → <strong>Comments</strong> → adjust who can comment.</li>
+<li>Repeat for any sensitive posts needing limited replies.</li>
+<li>Search for <strong>"Who can comment"</strong> in Settings to change account-wide defaults.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>When posting, tap <strong>Advanced settings</strong> → <strong>Who can comment</strong> and choose your audience.</li>
+<li>For existing posts, tap <strong>…</strong> on the post → <strong>Comments</strong> → adjust the comment audience.</li>
+<li>Use this control to limit replies before posting high-risk content.</li>
+<li>Combine with <strong>Hidden words</strong> to filter what slips through.</li>
+<li>Search for <strong>"Who can comment"</strong> if menu names change.</li>
+</ol>
+</details>
+<p><em>Notes: Pair with Hidden Words filters for maximum control.</em></p>
+<p><strong>Related terms:</strong> replies, comments, post audience.</p>
+</section>
+<section class="card" id="guide-story-audience-and-reply-controls">
+<h3>Story Audience &amp; Reply Controls</h3>
+<p class="lead"><strong>Why this matters:</strong> Stories are a common leak vector.</p>
+<p><strong>What you’ll change:</strong> Limit who sees your stories and who can reply or react.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>In <strong>Settings &amp; privacy</strong>, select <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Set your <strong>Viewers</strong> (Everyone, Followers, Close Friends, or hide specific people).</li>
+<li>Under <strong>Allow message replies</strong>, pick <strong>Off</strong> or <strong>Followers you follow back</strong>.</li>
+<li>Disable <strong>Allow sharing</strong> options if available.</li>
+<li>Search for <strong>"Story"</strong> if you don’t see the menu.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Story</strong>.</li>
+<li>Choose your audience (Hide story from…, Close Friends, Followers).</li>
+<li>Set <strong>Allow message replies</strong> to <strong>Off</strong> or <strong>Followers you follow back</strong>.</li>
+<li>Search for <strong>"Story"</strong> if the option moved.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Select <strong>Story</strong>.</li>
+<li>Adjust who sees your stories and manage the <strong>Hide story from…</strong> list.</li>
+<li>Set <strong>Allow message replies</strong> to your preferred audience.</li>
+<li>Use the search bar for <strong>"Story"</strong> if navigation changes.</li>
+</ol>
+</details>
+<p><em>Notes: Use <strong>Close Friends</strong> for sensitive content you only want trusted people to see.</em></p>
+<p><strong>Related terms:</strong> story privacy, reactions.</p>
+</section>
+<section class="card" id="guide-prevent-sharing-your-stories-and-posts">
+<h3>Prevent Others from Sharing Your Stories &amp; Posts</h3>
+<p class="lead"><strong>Why this matters:</strong> Stops your content being redistributed.</p>
+<p><strong>What you’ll change:</strong> Disable story resharing and sharing to messages.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Toggle off <strong>Allow sharing to story</strong> and any <strong>Allow sharing</strong> to messages options.</li>
+<li>Check <strong>Reels and Remix</strong> settings (below on the page) to keep photos/videos from being remixed.</li>
+<li>Review highlights to ensure old stories aren’t publicly available.</li>
+<li>Search for <strong>"sharing"</strong> if the settings moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Story</strong>.</li>
+<li>Disable <strong>Allow sharing to story</strong> and <strong>Sharing to messages</strong>.</li>
+<li>Scroll to <strong>Reels and Remix</strong> to disable sharing/remix for your posts.</li>
+<li>Search for <strong>"Allow sharing"</strong> if it’s not obvious.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Turn off <strong>Allow sharing</strong> options for stories and messages.</li>
+<li>Visit <strong>Reels and Remix</strong> to disable resharing of your photos/videos.</li>
+<li>Consider removing older stories from highlights if you no longer want them accessible.</li>
+<li>Use Settings search for <strong>"sharing"</strong> if you need to locate the toggle.</li>
+</ol>
+</details>
+<p><em>Notes: Screenshots and screen recordings can still capture content, so share cautiously.</em></p>
+<p><strong>Related terms:</strong> resharing, reposts.</p>
+</section>
+<section class="card" id="guide-control-reels-remix-and-downloading">
+<h3>Control Reels Remix &amp; Downloading</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces reuses of your media.</p>
+<p><strong>What you’ll change:</strong> Limit remixes and disable downloading of your reels.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Within <strong>Settings &amp; privacy</strong>, choose <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle off <strong>Allow for photos</strong> and <strong>Allow for videos</strong>.</li>
+<li>Disable <strong>Download your reels</strong> if the option appears.</li>
+<li>Repeat per post via the <strong>…</strong> menu on a reel if you need exceptions.</li>
+<li>Search for <strong>"Reels"</strong> if the placement changes.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Reels and Remix</strong>.</li>
+<li>Turn off remixing for photos and videos and disable reel downloads.</li>
+<li>For individual reels, tap <strong>…</strong> → <strong>Turn off remixing</strong> if you want selective control.</li>
+<li>Search Settings for <strong>"Remix"</strong> if the menu moved.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Select <strong>Reels and Remix</strong>.</li>
+<li>Disable remixes for your photos/videos and turn off reel downloads.</li>
+<li>Override per reel via the <strong>…</strong> menu if necessary.</li>
+<li>Use the Settings search for <strong>"Reels"</strong> if you don’t see it.</li>
+</ol>
+</details>
+<p><em>Notes: Turning off remixing limits in-app reuse, but downloads may still happen through third-party tools.</em></p>
+<p><strong>Related terms:</strong> remix, stitch, duets.</p>
+</section>
+<h2 class="guide-range-heading" id="range-16-30">Guides #16–30</h2>
+<section class="card" id="guide-sensitive-content-control">
+<h3>Sensitive Content Control (Explore/Reels/Recommendations)</h3>
+<p class="lead"><strong>Why this matters:</strong> Lowers exposure to sensitive topics and risky accounts.</p>
+<p><strong>What you’ll change:</strong> Set sensitive content exposure to <strong>Less</strong> or <strong>Limit Even More</strong>.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> or <strong>Account settings</strong>.</li>
+<li>Click <strong>Sensitive content control</strong>.</li>
+<li>Choose <strong>Less</strong> or <strong>Limit Even More</strong> (if offered) to reduce sensitive recommendations.</li>
+<li>Confirm your selection.</li>
+<li>Search for <strong>"Sensitive"</strong> if the menu name changed.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Suggested content</strong> (or <strong>Account settings</strong> on some builds) → <strong>Sensitive content control</strong>.</li>
+<li>Select <strong>Less</strong> or <strong>Limit Even More</strong> to dial down sensitive material in Explore/Reels.</li>
+<li>Save your choice.</li>
+<li>Use the settings search for <strong>"Sensitive content"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Choose <strong>Suggested content</strong> → <strong>Sensitive content control</strong>.</li>
+<li>Set it to <strong>Less</strong> or <strong>Limit Even More</strong> to reduce sensitive recommendations.</li>
+<li>Confirm the new level.</li>
+<li>Search for <strong>"Sensitive"</strong> if the option is in a different section.</li>
+</ol>
+</details>
+<p><em>Notes: This setting doesn’t affect accounts you already follow—curate your follows separately.</em></p>
+<p><strong>Related terms:</strong> explore, recommendations.</p>
+</section>
+<section class="card" id="guide-hide-like-and-view-counts">
+<h3>Hide Like &amp; View Counts</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces social pressure and engagement bait.</p>
+<p><strong>What you’ll change:</strong> Hide counts globally and/or per post.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Posts</strong>.</li>
+<li>Toggle on <strong>Hide like and view counts</strong>.</li>
+<li>For individual posts, open the post → <strong>…</strong> → <strong>Hide like count</strong>.</li>
+<li>Repeat for reels if prompted.</li>
+<li>Search for <strong>"Hide like"</strong> if the option moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Posts</strong>.</li>
+<li>Enable <strong>Hide like and view counts</strong>.</li>
+<li>Per post: tap <strong>…</strong> → <strong>Hide like count</strong>.</li>
+<li>Search for <strong>"like count"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Select <strong>Privacy</strong> → <strong>Posts</strong>.</li>
+<li>Toggle on <strong>Hide like and view counts</strong>.</li>
+<li>Adjust per post via <strong>…</strong> → <strong>Hide like count</strong> as desired.</li>
+<li>Use Settings search for <strong>"like"</strong> if layout changed.</li>
+</ol>
+</details>
+<p><em>Notes: Others can still like your posts; the counts just don’t display to you.</em></p>
+<p><strong>Related terms:</strong> mental health, engagement metrics.</p>
+</section>
+<section class="card" id="guide-message-controls-who-can-message-you">
+<h3>Message Controls (Who Can Message You)</h3>
+<p class="lead"><strong>Why this matters:</strong> Cuts spam and harassment in DMs.</p>
+<p><strong>What you’ll change:</strong> Decide who can start chats and where requests go.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages and story replies</strong>.</li>
+<li>Adjust each category (People on Instagram, Others) to <strong>Don’t receive requests</strong> or <strong>Message requests</strong>.</li>
+<li>Limit <strong>Group</strong> invitations to <strong>People you follow</strong>.</li>
+<li>Save changes.</li>
+<li>Search for <strong>"Message controls"</strong> if you can’t find the panel.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Messages and story replies</strong> → <strong>Message controls</strong>.</li>
+<li>For each category, set to <strong>Don’t receive requests</strong> or send to <strong>Message requests</strong>.</li>
+<li>Restrict group invites to people you follow.</li>
+<li>Search for <strong>"Message"</strong> if menus change.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Choose <strong>Messages and story replies</strong> → <strong>Message controls</strong>.</li>
+<li>Customize who can message you and where requests land.</li>
+<li>Limit group invitations to people you follow to reduce spam.</li>
+<li>Use Settings search for <strong>"Message"</strong> if necessary.</li>
+</ol>
+</details>
+<p><em>Notes: Pair with Hidden Words for DM keyword filtering.</em></p>
+<p><strong>Related terms:</strong> DM requests, inbox filtering.</p>
+</section>
+<section class="card" id="guide-restrict-mute-or-block-problem-accounts">
+<h3>Restrict, Mute, or Block Problem Accounts</h3>
+<p class="lead"><strong>Why this matters:</strong> Gives you tiers of control without confrontation.</p>
+<p><strong>What you’ll change:</strong> Apply <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong> to troublesome users.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Visit the profile you want to manage.</li>
+<li>Click <strong>…</strong> → choose <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong>.</li>
+<li>Confirm the action.</li>
+<li>Manage lists via <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Limited interactions</strong>/<strong>Blocked accounts</strong>.</li>
+<li>Search for <strong>"Blocked"</strong> if you need to adjust later.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Open the person’s profile → tap <strong>…</strong>.</li>
+<li>Select <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong> and confirm.</li>
+<li>To review, go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Restricted accounts</strong>/<strong>Muted accounts</strong>/<strong>Blocked accounts</strong>.</li>
+<li>Adjust or remove entries as needed.</li>
+<li>Search Settings for <strong>"Restrict"</strong> if you can’t locate the lists.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Navigate to the user’s profile → tap <strong>…</strong>.</li>
+<li>Choose <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong>, then confirm.</li>
+<li>Manage lists from <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → the relevant section (Limited interactions, Muted accounts, Blocked accounts).</li>
+<li>Unrestrict or unblock from the same lists when needed.</li>
+<li>Use Settings search for <strong>"Blocked"</strong> if options move.</li>
+</ol>
+</details>
+<p><em>Notes: Restrict hides your activity from them without notifying the other person.</em></p>
+<p><strong>Related terms:</strong> safety, harassment controls.</p>
+</section>
+<section class="card" id="guide-review-third-party-apps-websites">
+<h3>Review Third-Party Apps/Websites Connected to Instagram</h3>
+<p class="lead"><strong>Why this matters:</strong> Old app connections are a frequent leak.</p>
+<p><strong>What you’ll change:</strong> Remove access to apps or websites you no longer use.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Select <strong>Apps and websites</strong> or <strong>Logged in with Instagram</strong>.</li>
+<li>Under <strong>Active</strong>, click unwanted integrations and choose <strong>Remove</strong>.</li>
+<li>Repeat for the <strong>Expired</strong> list to clean up lingering access.</li>
+<li>Search for <strong>"Apps and websites"</strong> if the section moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Your information and permissions</strong> → <strong>Apps and websites</strong>.</li>
+<li>Review the <strong>Active</strong> tab, removing anything unfamiliar.</li>
+<li>Check <strong>Expired</strong> for leftovers and clear them as well.</li>
+<li>Search for <strong>"Apps"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Select <strong>Your information and permissions</strong> → <strong>Apps and websites</strong>.</li>
+<li>Remove any integration you don’t recognize or no longer need.</li>
+<li>Repeat periodically to keep access tight.</li>
+<li>Use Settings search for <strong>"Apps and websites"</strong> if it’s hidden.</li>
+</ol>
+</details>
+<p><em>Notes: Revoking access forces third parties to re-request permissions, giving you control over what’s connected.</em></p>
+<p><strong>Related terms:</strong> OAuth, app permissions.</p>
+</section>
+<section class="card" id="guide-ad-preferences-and-topics">
+<h3>Ad Preferences &amp; Topics (Meta Accounts Center)</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces tracking and sensitive ad inferences.</p>
+<p><strong>What you’ll change:</strong> Limit ad interests, categories, and off-site activity use.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
+<li>Review <strong>Ad topics</strong> and mark sensitive ones as <strong>See less</strong>.</li>
+<li>Open <strong>Ad settings</strong> to disable <strong>Use of activity from partners</strong> and ads shown off Meta where possible.</li>
+<li>Check <strong>Categories used to reach you</strong> and remove anything you don’t like.</li>
+<li>Search for <strong>"Ad preferences"</strong> if menus shift.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Ad preferences</strong>.</li>
+<li>Adjust <strong>Ad topics</strong>, <strong>Ad settings</strong>, and <strong>Categories used to reach you</strong>.</li>
+<li>Turn off partner activity usage where allowed.</li>
+<li>Search for <strong>"Ad"</strong> if you can’t find the section.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Select <strong>Ad preferences</strong>.</li>
+<li>Limit sensitive topics and restrict partner data usage under <strong>Ad settings</strong>.</li>
+<li>Remove personal categories you disagree with.</li>
+<li>Use Settings search for <strong>"Ad preferences"</strong> if it’s tucked away.</li>
+</ol>
+</details>
+<p><em>Notes: You’ll still see ads—they’ll just be less personalized and less sensitive.</em></p>
+<p><strong>Related terms:</strong> personalization, tracking, inferences.</p>
+</section>
+<section class="card" id="guide-off-meta-activity">
+<h3>Off-Meta Activity (Limit Data From Partners)</h3>
+<p class="lead"><strong>Why this matters:</strong> Controls how off-site activity informs ads.</p>
+<p><strong>What you’ll change:</strong> Manage partner data use and clear history.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Select <strong>Off-Meta activity</strong> (name may vary) → <strong>Manage</strong>.</li>
+<li>Clear history and choose to turn off future activity sharing if supported.</li>
+<li>Review connected businesses and remove ones you don’t trust.</li>
+<li>Search for <strong>"Off-Meta"</strong> or <strong>"Partner activity"</strong> if labels changed.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Your information and permissions</strong> → <strong>Off-Meta activity</strong> (or similar).</li>
+<li>Clear your history and disable future off-site activity sharing if available.</li>
+<li>Repeat periodically to keep partner data minimal.</li>
+<li>Use Settings search for <strong>"Off-Meta"</strong> if you can’t locate it.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Choose <strong>Your information and permissions</strong> → <strong>Off-Meta activity</strong>.</li>
+<li>Clear past activity and opt out of future partner data collection where possible.</li>
+<li>Remove any specific partners you don’t recognize.</li>
+<li>Search for <strong>"Off-Meta"</strong> if the setting is under Ad preferences.</li>
+</ol>
+</details>
+<p><em>Notes: Naming varies by region; look for partner data or activity sharing options.</em></p>
+<p><strong>Related terms:</strong> off-site data, partner signals.</p>
+</section>
+<section class="card" id="guide-close-friends-list">
+<h3>Close Friends List (Stories)</h3>
+<p class="lead"><strong>Why this matters:</strong> Share sensitive content to a trusted circle.</p>
+<p><strong>What you’ll change:</strong> Curate and use your <strong>Close Friends</strong> list.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to your profile → <strong>Menu (☰)</strong>.</li>
+<li>Choose <strong>Close Friends</strong> (if available) or open the story composer and select <strong>Close Friends</strong> to edit the list.</li>
+<li>Add or remove people to reflect who should see private stories.</li>
+<li>When posting a story, pick <strong>Close Friends</strong> to limit the audience.</li>
+<li>Search for <strong>"Close Friends"</strong> in Settings if you don’t see the option.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Close Friends</strong>.</li>
+<li>Use search to add trusted accounts or remove old entries.</li>
+<li>Before sharing a story, tap <strong>Close Friends</strong> so only that list sees it.</li>
+<li>Review the list regularly to keep it accurate.</li>
+<li>Search Settings for <strong>"Close Friends"</strong> if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Close Friends</strong>.</li>
+<li>Add or remove people quietly (no notifications are sent).</li>
+<li>Select <strong>Close Friends</strong> when posting a story to limit visibility.</li>
+<li>Revisit the list as your trust circle changes.</li>
+<li>Use the Settings search for <strong>"Close Friends"</strong> if the menu moved.</li>
+</ol>
+</details>
+<p><em>Notes: People aren’t notified when you adjust the list, so fine-tune it anytime.</em></p>
+<p><strong>Related terms:</strong> private circle, limited audience.</p>
+</section>
+<section class="card" id="guide-hide-your-profile-from-contacts">
+<h3>Hide Your Profile From Contacts/Discoverability</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces cross-app identification.</p>
+<p><strong>What you’ll change:</strong> Turn off contact syncing and discovery suggestions.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Account</strong> or <strong>Your information and permissions</strong>.</li>
+<li>Select <strong>Contacts syncing</strong> → toggle it off and delete previously uploaded contacts.</li>
+<li>Look for <strong>Discoverability</strong> or <strong>Suggesting your account</strong> and disable suggestions.</li>
+<li>Unlink Facebook in <strong>Accounts Center</strong> if you don’t want cross-recommendations.</li>
+<li>Search for <strong>"Contacts"</strong> or <strong>"Discoverability"</strong> if options moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Tap <strong>Account</strong> → <strong>Contacts syncing</strong> → toggle off and remove synced contacts.</li>
+<li>Back out → open <strong>Your information and permissions</strong> → <strong>Suggesting your account on other apps</strong> (if shown) → turn off.</li>
+<li>Review Facebook connection under <strong>Accounts Center</strong> and unlink if not needed.</li>
+<li>Search Settings for <strong>"Contacts"</strong> if you can’t find it.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Choose <strong>Account</strong> → <strong>Contacts syncing</strong> → turn off syncing and delete uploaded contacts.</li>
+<li>Under <strong>Your information and permissions</strong>, disable discoverability or suggestions if available.</li>
+<li>Unlink Facebook in <strong>Accounts Center</strong> to stop cross-platform recommendations.</li>
+<li>Use Settings search for <strong>"Contacts"</strong> or <strong>"Discover"</strong> if the layout changed.</li>
+</ol>
+</details>
+<p><em>Notes: Turning off syncing removes uploaded address-book data and limits “people you may know” exposure.</em></p>
+<p><strong>Related terms:</strong> address book, people you may know.</p>
+</section>
+<section class="card" id="guide-manage-comment-controls-per-post">
+<h3>Manage Comment Controls Per Post</h3>
+<p class="lead"><strong>Why this matters:</strong> Granular control for sensitive posts.</p>
+<p><strong>What you’ll change:</strong> Restrict comments on individual posts.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open the post → click <strong>…</strong> (three dots).</li>
+<li>Select <strong>Who can comment</strong> → choose <strong>People you follow</strong>, <strong>Followers you follow back</strong>, or <strong>Off</strong>.</li>
+<li>Use <strong>Block comments from</strong> to add specific accounts to the block list.</li>
+<li>Confirm changes.</li>
+<li>Search for <strong>"Comments"</strong> if the controls appear elsewhere.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Open your post → tap <strong>…</strong>.</li>
+<li>Tap <strong>Comments</strong>.</li>
+<li>Adjust <strong>Allow comments from</strong> and add accounts under <strong>Block comments from</strong>.</li>
+<li>Save and exit.</li>
+<li>Search Settings for <strong>"Comments"</strong> to set defaults if needed.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Open the post → tap <strong>…</strong>.</li>
+<li>Choose <strong>Comments</strong>.</li>
+<li>Set who can comment and block specific users from commenting.</li>
+<li>Tap <strong>Done</strong> to apply.</li>
+<li>Use Settings search for <strong>"Comments"</strong> if menus move.</li>
+</ol>
+</details>
+<p><em>Notes: Combine with global Hidden Words filters for best results.</em></p>
+<p><strong>Related terms:</strong> per-post privacy, moderation.</p>
+</section>
+<section class="card" id="guide-delete-face-tag-suggestions">
+<h3>Delete Face/Tag Suggestions on Old Posts</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces appearance in others’ tagging flows.</p>
+<p><strong>What you’ll change:</strong> Remove yourself from old tags and ensure manual approval stays on.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to your profile → select the <strong>Tagged</strong> tab.</li>
+<li>Open each post where you’re tagged → click <strong>…</strong> → <strong>Remove me from post</strong>.</li>
+<li>Return to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to confirm <strong>Manually approve tags</strong> is enabled.</li>
+<li>Repeat until unwanted tags are cleared.</li>
+<li>Search for <strong>"Tagged"</strong> in Settings if you need quick access.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Profile → <strong>Tagged</strong> tab → open a tagged post.</li>
+<li>Tap <strong>…</strong> → <strong>Remove me from post</strong>.</li>
+<li>Back in <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>, confirm <strong>Manually approve tags</strong> is on.</li>
+<li>Continue removing any other unwanted tags.</li>
+<li>Search Settings for <strong>"Tagged"</strong> if the tab is buried.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Tagged</strong>.</li>
+<li>Open a post → tap <strong>…</strong> → <strong>Remove me from post</strong>.</li>
+<li>Visit <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to ensure manual approval is active.</li>
+<li>Repeat as needed to clean up old tags.</li>
+<li>Use Settings search for <strong>"Tags"</strong> if the toggle has moved.</li>
+</ol>
+</details>
+<p><em>Notes: You can’t stop others from uploading photos, but you can refuse the tag link to your profile.</em></p>
+<p><strong>Related terms:</strong> facial recognition, tag graph.</p>
+</section>
+<section class="card" id="guide-limit-story-replies-to-close-friends">
+<h3>Limit Story Replies to Close Friends Only</h3>
+<p class="lead"><strong>Why this matters:</strong> Stops massive DM floods on stories.</p>
+<p><strong>What you’ll change:</strong> Only <strong>Close Friends</strong> can reply to your stories.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Under <strong>Allow message replies</strong>, choose <strong>Close Friends</strong> or <strong>Off</strong>.</li>
+<li>Confirm the change.</li>
+<li>Adjust <strong>Hide story from…</strong> for additional exclusions if needed.</li>
+<li>Search for <strong>"Story replies"</strong> if you can’t locate it.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Set <strong>Allow message replies</strong> to <strong>Close Friends</strong> or <strong>Off</strong>.</li>
+<li>Save and exit.</li>
+<li>Review your Close Friends list to ensure only trusted people can respond.</li>
+<li>Search Settings for <strong>"Story replies"</strong> if necessary.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Choose <strong>Close Friends</strong> under <strong>Allow message replies</strong>.</li>
+<li>Optionally hide the story from specific people for extra control.</li>
+<li>Exit to save.</li>
+<li>Use Settings search for <strong>"Story"</strong> if menus changed.</li>
+</ol>
+</details>
+<p><em>Notes: Combine with a curated Close Friends list for maximum control.</em></p>
+<p><strong>Related terms:</strong> story replies, reactions.</p>
+</section>
+<section class="card" id="guide-quiet-mode-notification-controls">
+<h3>Quiet Mode / Notification Controls</h3>
+<p class="lead"><strong>Why this matters:</strong> Reduces unwanted attention windows.</p>
+<p><strong>What you’ll change:</strong> Schedule Quiet mode and fine-tune notifications.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Adjust categories like <strong>Messages</strong>, <strong>Comments</strong>, and <strong>Tags</strong> to reduce alerts.</li>
+<li>Set email and SMS notification preferences to the minimum you need.</li>
+<li>Repeat periodically to stay focused.</li>
+<li>Search for <strong>"Notifications"</strong> if the section is renamed.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Tap <strong>Quiet mode</strong> → schedule start/end times.</li>
+<li>Adjust individual notification categories (Messages, Comments, Tags, Followers) to limit interruptions.</li>
+<li>Review push vs. email alerts to avoid duplicates.</li>
+<li>Search for <strong>"Quiet mode"</strong> if the option isn’t obvious.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Enable <strong>Quiet mode</strong> and set the schedule.</li>
+<li>Customize categories to limit DM, comment, and live notifications.</li>
+<li>Check email/SMS notification settings to reduce noise.</li>
+<li>Use Settings search for <strong>"Quiet"</strong> if needed.</li>
+</ol>
+</details>
+<p><em>Notes: Quiet mode can auto-reply to DMs to indicate you’re away.</em></p>
+<p><strong>Related terms:</strong> do not disturb, focus.</p>
+</section>
+<section class="card" id="guide-download-your-information-export">
+<h3>Download Your Information (Export)</h3>
+<p class="lead"><strong>Why this matters:</strong> Backups help audits and incident response.</p>
+<p><strong>What you’ll change:</strong> Request and download a copy of your data.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Select <strong>Download your information</strong>.</li>
+<li>Choose Instagram, set the date range and format, and click <strong>Request a download</strong>.</li>
+<li>Wait for the email or in-app notification, then download securely.</li>
+<li>Search for <strong>"Download"</strong> if the menu moved.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
-<li>Select Instagram, choose the date range and format, then tap <strong>Request a download</strong>.</li>
+<li>Select Instagram, pick a date range and format, then tap <strong>Request a download</strong>.</li>
+<li>Use the link sent via email or in-app notification to retrieve the archive.</li>
+<li>Search Settings for <strong>"Download"</strong> if needed.</li>
 </ol>
 </details>
 <details>
-<summary>On Desktop</summary>
+<summary>On iOS</summary>
 <ol>
-<li><strong>instagram.com</strong> → <strong>More</strong> → <strong>Settings</strong> → <strong>Accounts Center</strong>.</li>
-<li>Go to <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
-<li>Pick Instagram data, set your filters, and click <strong>Request a download</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Select <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
+<li>Choose Instagram, timeframe, and format, then submit the request.</li>
+<li>Download the archive once you receive the notification.</li>
+<li>Use Settings search for <strong>"Download"</strong> if the option is hidden.</li>
 </ol>
 </details>
-<p class="lead"><strong>Tips:</strong> Reviewing your archive helps you decide what to delete or tighten in privacy controls.</p>
+<p><em>Notes: Store exports securely—they contain private messages, photos, and metadata.</em></p>
+<p><strong>Related terms:</strong> data portability, GDPR export.</p>
+</section>
+<section class="card" id="guide-delete-search-history-and-suggested-results">
+<h3>Delete Search History &amp; Suggested Results</h3>
+<p class="lead"><strong>Why this matters:</strong> Clears sensitive searches from influencing suggestions.</p>
+<p><strong>What you’ll change:</strong> Clear recent searches and adjust suggested content.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Click the <strong>Search</strong> icon → select the search bar.</li>
+<li>If <strong>Clear all</strong> appears, choose it to erase recent searches.</li>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to tune recommendations.</li>
+<li>Adjust preferences or mute topics you don’t want.</li>
+<li>Search for <strong>"Suggested content"</strong> if the menu changed.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Tap <strong>Search</strong> → tap the bar → choose <strong>See all</strong>.</li>
+<li>Tap <strong>Clear all</strong> to remove recent searches.</li>
+<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to manage preferences.</li>
+<li>Adjust categories or mute suggestions tied to past activity.</li>
+<li>Search Settings for <strong>"Suggested"</strong> if necessary.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Open the <strong>Search</strong> tab → tap the search bar → tap <strong>See all</strong>.</li>
+<li>Select <strong>Clear all</strong> to wipe recent searches.</li>
+<li>Visit <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to refine what appears.</li>
+<li>Mute or limit topics you don’t want recommended.</li>
+<li>Use Settings search for <strong>"Suggested"</strong> if the option has moved.</li>
+</ol>
+</details>
+<p><em>Notes: Suggestions also depend on what you watch or follow, so curate those feeds too.</em></p>
+<p><strong>Related terms:</strong> search privacy, recommendations.</p>
 </section>
 </div>
 <aside aria-label="On this page" class="platform-sidebar">
@@ -338,7 +1232,8 @@
 <ul>
 <li><a href="#navigation-primer">Navigation primer</a></li>
 <li><a href="#guide-index">Guide index</a></li>
-<li><a href="#range-1-12">Guides #1–12</a></li>
+<li><a href="#range-1-15">Guides #1–15</a></li>
+<li><a href="#range-16-30">Guides #16–30</a></li>
 </ul>
 </nav>
 </div>


### PR DESCRIPTION
## Summary
- replace the Instagram platform page with 30 structured privacy guides that cover account security, privacy, and safety controls
- update the navigation index and sidebar to reflect the expanded guide ranges and new layout requirements

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e4a1a2fb38832391949eff4c29d6b4