### PR TITLE
Add Instagram guides batch 2

### DIFF
--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -110,6 +110,37 @@
 <li><a href="#guide-quiet-mode-notification-controls">Quiet Mode / Notification Controls</a></li>
 <li><a href="#guide-download-your-information-export">Download Your Information (Export)</a></li>
 <li><a href="#guide-delete-search-history-and-suggested-results">Delete Search History &amp; Suggested Results</a></li>
+<li class="guide-range-divider"><span>Guides #31–60</span></li>
+<li><a href="#guide-unlink-facebook-threads-other-linked-accounts">Unlink Facebook / Threads / Other Linked Accounts</a></li>
+<li><a href="#guide-turn-off-log-in-with-facebook-meta-and-use-email-password">Turn Off “Log in with Facebook/Meta” and Use Email/Password</a></li>
+<li><a href="#guide-turn-off-contact-syncing-and-delete-uploaded-contacts">Turn Off Contact Syncing and Delete Uploaded Contacts</a></li>
+<li><a href="#guide-turn-off-cross-app-friend-suggestions-facebook-to-instagram">Turn Off Cross-App Friend Suggestions (Facebook → Instagram)</a></li>
+<li><a href="#guide-turn-off-similar-account-suggestions">Turn Off “Similar Account Suggestions”</a></li>
+<li><a href="#guide-turn-off-face-recognition-if-you-see-it">Turn Off Face Recognition (If You See It)</a></li>
+<li><a href="#guide-stop-automatically-sharing-stories-to-facebook">Stop Automatically Sharing Stories to Facebook</a></li>
+<li><a href="#guide-stop-automatically-sharing-posts-to-facebook">Stop Automatically Sharing Posts to Facebook</a></li>
+<li><a href="#guide-turn-off-cross-app-interactions-story-reactions-from-facebook">Turn Off Cross-App Interactions (Story Reactions from Facebook)</a></li>
+<li><a href="#guide-hide-your-stories-from-specific-people">Hide Your Stories from Specific People</a></li>
+<li><a href="#guide-hide-your-reels-from-specific-people">Hide Your Reels from Specific People</a></li>
+<li><a href="#guide-restrict-an-account-quietly-limit-them">Restrict an Account (Quietly Limit Them)</a></li>
+<li><a href="#guide-block-keyword-sets-in-dms-hidden-words">Block Keyword Sets in DMs (Hidden Words)</a></li>
+<li><a href="#guide-turn-off-read-receipts-in-dms-if-you-see-the-option">Turn Off Read Receipts in DMs (If You See the Option)</a></li>
+<li><a href="#guide-use-vanish-mode-for-sensitive-chats">Use Vanish Mode for Sensitive Chats</a></li>
+<li><a href="#guide-stop-message-requests-from-non-followers">Stop Message Requests from Non-Followers</a></li>
+<li><a href="#guide-limit-who-can-add-you-to-group-chats">Limit Who Can Add You to Group Chats</a></li>
+<li><a href="#guide-turn-on-limits-to-temporarily-restrict-new-interactions">Turn On “Limits” to Temporarily Restrict New Interactions</a></li>
+<li><a href="#guide-remove-specific-viewers-from-a-live-story-while-active">Remove Specific Viewers from a Live Story (While Active)</a></li>
+<li><a href="#guide-stop-automatically-sharing-reels-to-facebook">Stop Automatically Sharing Reels to Facebook</a></li>
+<li><a href="#guide-allow-only-emoji-story-replies">Allow Only Emoji Story Replies</a></li>
+<li><a href="#guide-require-approval-before-tagged-photos-appear">Require Approval Before Tagged Photos Appear</a></li>
+<li><a href="#guide-disable-remix-for-photos">Disable Remix for Photos</a></li>
+<li><a href="#guide-disable-remix-for-videos">Disable Remix for Videos</a></li>
+<li><a href="#guide-disable-downloading-of-your-reels">Disable Downloading of Your Reels</a></li>
+<li><a href="#guide-clear-off-meta-activity-and-turn-off-future-activity">Clear Off-Meta Activity and Turn Off Future Activity</a></li>
+<li><a href="#guide-limit-sensitive-content-in-explore-reels">Limit Sensitive Content in Explore/Reels</a></li>
+<li><a href="#guide-remove-followers-without-blocking">Remove Followers (Without Blocking)</a></li>
+<li><a href="#guide-turn-off-personalized-ads-partner-activity">Turn Off Personalized Ads (Partner Activity)</a></li>
+<li><a href="#guide-remove-yourself-from-existing-tagged-posts">Remove Yourself from Existing Tagged Posts</a></li>
 </ol>
 </nav>
 <h2 class="guide-range-heading" id="range-1-15">Guides #1–15</h2>
@@ -1224,6 +1255,814 @@
 <p><em>Notes: Suggestions also depend on what you watch or follow, so curate those feeds too.</em></p>
 <p><strong>Related terms:</strong> search privacy, recommendations.</p>
 </section>
+<h2 class="guide-range-heading" id="range-31-60">Guides #31–60</h2>
+<section class="card" id="guide-unlink-facebook-threads-other-linked-accounts">
+<h3>Unlink Facebook / Threads / Other Linked Accounts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open Instagram and sign in.</li>
+<li>Click your <strong>profile picture</strong> (top right).</li>
+<li>Click <strong>Settings &amp; privacy</strong>.</li>
+<li>Scroll down and click <strong>Accounts Center</strong> (Meta window opens inside Instagram).</li>
+<li>In Accounts Center, click <strong>Connected experiences</strong>.</li>
+<li>Click <strong>Sharing across profiles</strong> or <strong>Connected profiles</strong>.</li>
+<li>Click the <strong>Facebook</strong>/<strong>Threads</strong> account you want to unlink.</li>
+<li>Click <strong>Remove from Accounts Center</strong>.</li>
+<li>Confirm <strong>Remove</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open Instagram.</li>
+<li>Tap your <strong>profile picture</strong> (bottom right).</li>
+<li>Tap the <strong>≡</strong> menu (top right) → <strong>Settings and privacy</strong>.</li>
+<li>Scroll to <strong>Accounts Center</strong> and tap it.</li>
+<li>Tap <strong>Connected experiences</strong> → <strong>Sharing across profiles</strong> or <strong>Connected profiles</strong>.</li>
+<li>Tap the linked <strong>Facebook/Threads</strong> account.</li>
+<li>Tap <strong>Remove from Accounts Center</strong> → <strong>Remove</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open Instagram.</li>
+<li>Tap your <strong>profile picture</strong> (bottom right).</li>
+<li>Tap the <strong>≡</strong> menu (top right) → <strong>Settings and privacy</strong>.</li>
+<li>Scroll and tap <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Connected experiences</strong> → <strong>Sharing across profiles</strong>/<strong>Connected profiles</strong>.</li>
+<li>Select the linked account.</li>
+<li>Tap <strong>Remove from Accounts Center</strong> → <strong>Remove</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-log-in-with-facebook-meta-and-use-email-password">
+<h3>Turn Off “Log in with Facebook/Meta” and Use Email/Password</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile picture (top right) → <strong>Settings &amp; privacy</strong>.</li>
+<li>Click <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Login &amp; account settings</strong> (or <strong>Password and security</strong>).</li>
+<li>Turn <strong>Log in with Facebook</strong> <strong>OFF</strong> (if shown).</li>
+<li>Go back → click <strong>Password</strong>/<strong>Change password</strong> and set a strong password for Instagram.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Login &amp; account settings</strong>.</li>
+<li>Turn <strong>Log in with Facebook</strong> <strong>OFF</strong> (if shown).</li>
+<li>Back → <strong>Password and security</strong> → <strong>Change password</strong> → set a new password.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Login &amp; account settings</strong>.</li>
+<li>Turn <strong>Log in with Facebook</strong> <strong>OFF</strong>.</li>
+<li>Back → <strong>Password and security</strong> → <strong>Change password</strong> → set a new password.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-contact-syncing-and-delete-uploaded-contacts">
+<h3>Turn Off Contact Syncing and Delete Uploaded Contacts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile picture (top right) → <strong>Settings &amp; privacy</strong>.</li>
+<li>Click <strong>Account</strong> (or <strong>Your information and permissions</strong>).</li>
+<li>Click <strong>Contacts syncing</strong> → turn <strong>Sync contacts</strong> <strong>OFF</strong>.</li>
+<li>Click <strong>Manage contacts</strong> → <strong>Delete all contacts</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Scroll to <strong>Account</strong> → <strong>Contacts syncing</strong>.</li>
+<li>Turn <strong>Connect contacts</strong> <strong>OFF</strong>.</li>
+<li>Tap <strong>Manage contacts</strong> → <strong>Delete all contacts</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Tap <strong>Account</strong> → <strong>Contacts syncing</strong>.</li>
+<li>Turn <strong>Connect contacts</strong> <strong>OFF</strong>.</li>
+<li>Tap <strong>Manage contacts</strong> → <strong>Delete all contacts</strong> → confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-cross-app-friend-suggestions-facebook-to-instagram">
+<h3>Turn Off Cross-App Friend Suggestions (Facebook → Instagram)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Connected experiences</strong>.</li>
+<li>Click <strong>Cross-app friends</strong> (or similar).</li>
+<li>Turn <strong>Friend suggestions</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Connected experiences</strong> → <strong>Cross-app friends</strong>.</li>
+<li>Turn <strong>Friend suggestions</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Connected experiences</strong> → <strong>Cross-app friends</strong>.</li>
+<li>Turn <strong>Friend suggestions</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-similar-account-suggestions">
+<h3>Turn Off “Similar Account Suggestions”</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Click <strong>Edit profile</strong>.</li>
+<li>Scroll to <strong>Similar account suggestions</strong>.</li>
+<li>Uncheck <strong>Include your account when recommending similar accounts people might want to follow</strong>.</li>
+<li>Click <strong>Submit</strong>/<strong>Save</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Account</strong>.</li>
+<li>Tap <strong>Discoverability</strong> (or <strong>Suggested accounts</strong>) if present.</li>
+<li>Turn suggestion toggles <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Account</strong>.</li>
+<li>Tap <strong>Discoverability</strong>/<strong>Suggested accounts</strong> (if present).</li>
+<li>Turn suggestion toggles <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-face-recognition-if-you-see-it">
+<h3>Turn Off Face Recognition (If You See It)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Click <strong>Face recognition</strong>.</li>
+<li>Turn it <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Face recognition</strong> (if shown) → <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Tap <strong>Face recognition</strong> (if shown) → <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-stop-automatically-sharing-stories-to-facebook">
+<h3>Stop Automatically Sharing Stories to Facebook</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Sharing across profiles</strong>.</li>
+<li>Click your <strong>Instagram → Facebook</strong> pairing.</li>
+<li>Click <strong>Story</strong> → turn <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Sharing across profiles</strong> → pick <strong>Instagram → Facebook</strong>.</li>
+<li>Tap <strong>Story</strong> → toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Sharing across profiles</strong> → choose <strong>Instagram → Facebook</strong>.</li>
+<li><strong>Story</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-stop-automatically-sharing-posts-to-facebook">
+<h3>Stop Automatically Sharing Posts to Facebook</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li>Select <strong>Instagram → Facebook</strong>.</li>
+<li>Click <strong>Feed</strong> → turn <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li>Pick <strong>Instagram → Facebook</strong>.</li>
+<li>Tap <strong>Feed</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li><strong>Instagram → Facebook</strong> → <strong>Feed</strong>.</li>
+<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-cross-app-interactions-story-reactions-from-facebook">
+<h3>Turn Off Cross-App Interactions (Story Reactions from Facebook)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Connected experiences</strong> → <strong>Interactions</strong> (or similar).</li>
+<li>Turn cross-app reactions/messages <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Connected experiences</strong> → <strong>Interactions</strong>.</li>
+<li>Turn cross-app reactions/messages <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Connected experiences</strong> → <strong>Interactions</strong>.</li>
+<li>Turn cross-app reactions/messages <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-hide-your-stories-from-specific-people">
+<h3>Hide Your Stories from Specific People</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Click <strong>Hide story from</strong>.</li>
+<li>Search for people → click to select → <strong>Done</strong>/<strong>Save</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Tap <strong>Hide story from</strong> → pick people → <strong>Done</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li><strong>Hide story from</strong> → select people → <strong>Done</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-hide-your-reels-from-specific-people">
+<h3>Hide Your Reels from Specific People</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels</strong> (or <strong>Reels and Remix</strong>).</li>
+<li>Click <strong>Hide reels from</strong> → select accounts → <strong>Save</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels</strong> (or <strong>Reels and Remix</strong>).</li>
+<li><strong>Hide reels from</strong> → select accounts → <strong>Done</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels</strong> (or <strong>Reels and Remix</strong>).</li>
+<li><strong>Hide reels from</strong> → select accounts → <strong>Done</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-restrict-an-account-quietly-limit-them">
+<h3>Restrict an Account (Quietly Limit Them)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open the person’s <strong>profile</strong>.</li>
+<li>Click <strong>…</strong> (three dots) → <strong>Restrict</strong> → <strong>Restrict account</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open the person’s <strong>profile</strong>.</li>
+<li>Tap <strong>…</strong> (top right) → <strong>Restrict</strong> → <strong>Restrict account</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open the person’s <strong>profile</strong>.</li>
+<li>Tap <strong>…</strong> (top right) → <strong>Restrict</strong> → <strong>Restrict account</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-block-keyword-sets-in-dms-hidden-words">
+<h3>Block Keyword Sets in DMs (Hidden Words)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Turn on filtering.</li>
+<li>Click <strong>Manage custom words and phrases</strong> → add words/phrases → <strong>Save</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Turn on filters.</li>
+<li><strong>Manage custom words and phrases</strong> → add items → <strong>Save</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Turn on filters.</li>
+<li><strong>Manage custom words and phrases</strong> → add items → <strong>Save</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-read-receipts-in-dms-if-you-see-the-option">
+<h3>Turn Off Read Receipts in DMs (If You See the Option)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>Click <strong>i</strong> (chat details) or <strong>…</strong> if available.</li>
+<li>Turn <strong>Read receipts</strong> <strong>OFF</strong> (if present).</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>Tap <strong>…</strong> (top right) → <strong>Privacy settings</strong>.</li>
+<li>Turn <strong>Read receipts</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>Tap <strong>…</strong> (top right) → <strong>Privacy settings</strong>.</li>
+<li>Turn <strong>Read receipts</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-use-vanish-mode-for-sensitive-chats">
+<h3>Use Vanish Mode for Sensitive Chats</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>If <strong>Vanish mode</strong> is available, turn it on in chat settings; otherwise skip on web.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>Swipe up from the bottom of the chat and hold until <strong>Vanish mode</strong> turns on.</li>
+<li>Send messages; they disappear when seen and you leave the chat.</li>
+<li>To turn it off, swipe up again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open a <strong>chat</strong>.</li>
+<li>Swipe up from the bottom of the chat and hold until <strong>Vanish mode</strong> turns on.</li>
+<li>Send messages; they disappear when seen and you leave the chat.</li>
+<li>To turn it off, swipe up again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-stop-message-requests-from-non-followers">
+<h3>Stop Message Requests from Non-Followers</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li>Under <strong>Other people</strong>, set to <strong>Don’t receive requests</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li>Set <strong>Others on Instagram</strong> to <strong>Don’t receive requests</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li>Set <strong>Others on Instagram</strong> to <strong>Don’t receive requests</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-limit-who-can-add-you-to-group-chats">
+<h3>Limit Who Can Add You to Group Chats</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li>Find <strong>Who can add you to groups</strong> → choose <strong>People you follow</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li><strong>Group invites</strong> → choose <strong>People you follow</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li><strong>Group invites</strong> → choose <strong>People you follow</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-on-limits-to-temporarily-restrict-new-interactions">
+<h3>Turn On “Limits” to Temporarily Restrict New Interactions</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Limits</strong>.</li>
+<li>Click <strong>Continue</strong>.</li>
+<li>Choose who to limit (e.g., <strong>Accounts that don’t follow you</strong> or <strong>New followers</strong>).</li>
+<li>Set duration → <strong>Turn on</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Limits</strong>.</li>
+<li><strong>Continue</strong> → choose groups to limit → set time → <strong>Turn on</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Limits</strong>.</li>
+<li><strong>Continue</strong> → choose groups to limit → set time → <strong>Turn on</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-specific-viewers-from-a-live-story-while-active">
+<h3>Remove Specific Viewers from a Live Story (While Active)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open your <strong>active story</strong>.</li>
+<li>Click <strong>Viewers</strong>.</li>
+<li>Use available options to <strong>Hide story</strong> from specific accounts.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open your <strong>active story</strong>.</li>
+<li>Swipe up to see <strong>Viewers</strong>.</li>
+<li>Tap the <strong>⋯</strong> next to a viewer → <strong>Hide story</strong> from that person (or <strong>Remove</strong> if shown).</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open your <strong>active story</strong>.</li>
+<li>Swipe up to see <strong>Viewers</strong>.</li>
+<li>Tap the <strong>⋯</strong> next to a viewer → <strong>Hide story</strong> from that person (or <strong>Remove</strong> if shown).</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-stop-automatically-sharing-reels-to-facebook">
+<h3>Stop Automatically Sharing Reels to Facebook</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li>Choose <strong>Instagram → Facebook</strong>.</li>
+<li>Click <strong>Reels</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li>Pick <strong>Instagram → Facebook</strong> → <strong>Reels</strong>.</li>
+<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
+<li>Pick <strong>Instagram → Facebook</strong> → <strong>Reels</strong>.</li>
+<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-allow-only-emoji-story-replies">
+<h3>Allow Only Emoji Story Replies</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Under <strong>Allow message replies</strong>, choose <strong>Emoji reactions only</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li><strong>Allow message replies</strong> → <strong>Emoji reactions only</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li><strong>Allow message replies</strong> → <strong>Emoji reactions only</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-require-approval-before-tagged-photos-appear">
+<h3>Require Approval Before Tagged Photos Appear</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li>Turn <strong>Manually approve tags</strong> <strong>ON</strong>.</li>
+<li>Review the <strong>Tagged posts</strong> queue and approve/deny.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li>Turn <strong>Manually approve tags</strong> <strong>ON</strong>.</li>
+<li>Open <strong>Tagged posts</strong> and approve/deny.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li>Turn <strong>Manually approve tags</strong> <strong>ON</strong>.</li>
+<li>Open <strong>Tagged posts</strong> and approve/deny.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-disable-remix-for-photos">
+<h3>Disable Remix for Photos</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Turn <strong>Allow remixing for photos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Allow remixing for photos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Allow remixing for photos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-disable-remix-for-videos">
+<h3>Disable Remix for Videos</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Turn <strong>Allow remixing for videos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Allow remixing for videos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Allow remixing for videos</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-disable-downloading-of-your-reels">
+<h3>Disable Downloading of Your Reels</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Turn <strong>Allow downloading</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Download your reels</strong> <strong>OFF</strong> (or <strong>Allow downloading</strong> <strong>OFF</strong>).</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Toggle <strong>Download your reels</strong> <strong>OFF</strong> (or <strong>Allow downloading</strong> <strong>OFF</strong>).</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-clear-off-meta-activity-and-turn-off-future-activity">
+<h3>Clear Off-Meta Activity and Turn Off Future Activity</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Your information and permissions</strong>.</li>
+<li>Click <strong>Off-Meta activity</strong> → <strong>Manage activity</strong> → <strong>Clear history</strong>.</li>
+<li>Turn <strong>Future Off-Meta activity</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li><strong>Off-Meta activity</strong> → <strong>Manage</strong> → <strong>Clear history</strong>.</li>
+<li>Turn <strong>Future activity</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li><strong>Off-Meta activity</strong> → <strong>Manage</strong> → <strong>Clear history</strong>.</li>
+<li>Turn <strong>Future activity</strong> <strong>OFF</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-limit-sensitive-content-in-explore-reels">
+<h3>Limit Sensitive Content in Explore/Reels</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> (or <strong>Account settings</strong>).</li>
+<li>Click <strong>Sensitive content control</strong>.</li>
+<li>Choose <strong>Limit even more</strong> (or the strictest option).</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Suggested content</strong>.</li>
+<li>Tap <strong>Sensitive content control</strong> → choose the strictest option.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Suggested content</strong>.</li>
+<li>Tap <strong>Sensitive content control</strong> → choose the strictest option.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-followers-without-blocking">
+<h3>Remove Followers (Without Blocking)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → click <strong>Followers</strong>.</li>
+<li>Find the person → click <strong>Remove</strong> next to their name → <strong>Remove</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → tap <strong>Followers</strong>.</li>
+<li>Find the person → tap <strong>Remove</strong> → <strong>Remove</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → tap <strong>Followers</strong>.</li>
+<li>Find the person → tap <strong>Remove</strong> → <strong>Remove</strong> again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-personalized-ads-partner-activity">
+<h3>Turn Off Personalized Ads (Partner Activity)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
+<li>Click <strong>Ad settings</strong>.</li>
+<li>Turn <strong>Use activity from partners</strong> <strong>OFF</strong>.</li>
+<li>Turn <strong>Show ads based on activity on Meta products</strong> <strong>OFF</strong> (where available).</li>
+<li>Review <strong>Ad topics</strong> and turn off sensitive topics.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Ad settings</strong>.</li>
+<li>Turn <strong>Use activity from partners</strong> <strong>OFF</strong>.</li>
+<li>Turn <strong>Ads based on your activity</strong> <strong>OFF</strong> (if shown).</li>
+<li>Review <strong>Ad topics</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Ad settings</strong>.</li>
+<li>Turn <strong>Use activity from partners</strong> <strong>OFF</strong>.</li>
+<li>Turn <strong>Ads based on your activity</strong> <strong>OFF</strong> (if shown).</li>
+<li>Review <strong>Ad topics</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-yourself-from-existing-tagged-posts">
+<h3>Remove Yourself from Existing Tagged Posts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → click the <strong>Tagged</strong> tab.</li>
+<li>Open a post where you are tagged.</li>
+<li>Click the <strong>⋯</strong> on the post → <strong>Tag options</strong> → <strong>Remove me from post</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → open the <strong>Tagged</strong> tab.</li>
+<li>Open a tagged post → tap <strong>⋯</strong> → <strong>Tag options</strong> (or <strong>Tag settings</strong>).</li>
+<li>Tap <strong>Remove me from post</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → open the <strong>Tagged</strong> tab.</li>
+<li>Open a tagged post → tap <strong>⋯</strong> → <strong>Tag options</strong> (or <strong>Tag settings</strong>).</li>
+<li>Tap <strong>Remove me from post</strong> → confirm.</li>
+</ol>
+</details>
+</section>
 </div>
 <aside aria-label="On this page" class="platform-sidebar">
 <div class="card toc-card">
@@ -1234,6 +2073,7 @@
 <li><a href="#guide-index">Guide index</a></li>
 <li><a href="#range-1-15">Guides #1–15</a></li>
 <li><a href="#range-16-30">Guides #16–30</a></li>
+<li><a href="#range-31-60">Guides #31–60</a></li>
 </ul>
 </nav>
 </div>


### PR DESCRIPTION
## Summary
- add navigation links and cards for Instagram guides 31-60
- include new section heading for the additional guides and update sidebar toc
- document unlinking, sharing, messaging, ads, and safety settings for web, Android, and iOS

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e4a7587b448323a4bdeef290095f63