### PR TITLE
Add Instagram cleanup guides batch 3

### DIFF
--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -141,6 +141,37 @@
 <li><a href="#guide-remove-followers-without-blocking">Remove Followers (Without Blocking)</a></li>
 <li><a href="#guide-turn-off-personalized-ads-partner-activity">Turn Off Personalized Ads (Partner Activity)</a></li>
 <li><a href="#guide-remove-yourself-from-existing-tagged-posts">Remove Yourself from Existing Tagged Posts</a></li>
+<li class="guide-range-divider"><span>Guides #61–90</span></li>
+<li><a href="#guide-delete-an-individual-post">Delete an Individual Post</a></li>
+<li><a href="#guide-bulk-delete-multiple-posts">Bulk Delete Multiple Posts</a></li>
+<li><a href="#guide-archive-a-post-instead-of-deleting">Archive a Post Instead of Deleting</a></li>
+<li><a href="#guide-restore-archived-posts">Restore Archived Posts</a></li>
+<li><a href="#guide-delete-a-story-highlight">Delete a Story Highlight</a></li>
+<li><a href="#guide-remove-a-single-story-from-a-highlight">Remove a Single Story from a Highlight</a></li>
+<li><a href="#guide-delete-a-reel">Delete a Reel</a></li>
+<li><a href="#guide-remove-yourself-from-a-tagged-photo">Remove Yourself from a Tagged Photo</a></li>
+<li><a href="#guide-review-and-remove-all-tagged-photos">Review and Remove All Tagged Photos</a></li>
+<li><a href="#guide-delete-a-comment-you-made">Delete a Comment You Made</a></li>
+<li><a href="#guide-delete-comments-on-your-post">Delete Comments on Your Post</a></li>
+<li><a href="#guide-turn-off-commenting-on-a-post">Turn Off Commenting on a Post</a></li>
+<li><a href="#guide-hide-offensive-comments-automatically">Hide Offensive Comments Automatically</a></li>
+<li><a href="#guide-remove-a-follower-without-blocking">Remove a Follower Without Blocking</a></li>
+<li><a href="#guide-block-a-user">Block a User</a></li>
+<li><a href="#guide-unblock-a-user">Unblock a User</a></li>
+<li><a href="#guide-restrict-a-user">Restrict a User</a></li>
+<li><a href="#guide-mute-a-user">Mute a User</a></li>
+<li><a href="#guide-report-a-post">Report a Post</a></li>
+<li><a href="#guide-report-a-user">Report a User</a></li>
+<li><a href="#guide-clear-search-history">Clear Search History</a></li>
+<li><a href="#guide-clear-suggested-accounts">Clear Suggested Accounts</a></li>
+<li><a href="#guide-disconnect-an-app-from-instagram">Disconnect an App from Instagram</a></li>
+<li><a href="#guide-download-your-account-data">Download Your Account Data</a></li>
+<li><a href="#guide-delete-your-account-permanently">Delete Your Account Permanently</a></li>
+<li><a href="#guide-deactivate-your-account-temporarily">Deactivate Your Account Temporarily</a></li>
+<li><a href="#guide-remove-a-saved-post">Remove a Saved Post</a></li>
+<li><a href="#guide-delete-a-message-thread">Delete a Message Thread</a></li>
+<li><a href="#guide-delete-a-single-message">Delete a Single Message</a></li>
+<li><a href="#guide-log-out-of-all-devices">Log Out of All Devices</a></li>
 </ol>
 </nav>
 <h2 class="guide-range-heading" id="range-1-15">Guides #1–15</h2>
@@ -2063,6 +2094,755 @@
 </ol>
 </details>
 </section>
+<h2 class="guide-range-heading" id="range-61-90">Guides #61–90</h2>
+<section class="card" id="guide-delete-an-individual-post">
+<h3>Delete an Individual Post</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to <strong>instagram.com</strong> and sign in.</li>
+<li>Click your <strong>profile picture</strong> in the top right to open your profile.</li>
+<li>Click the <strong>post</strong> you want to delete.</li>
+<li>Click the <strong>⋯</strong> in the top right corner.</li>
+<li>Select <strong>Delete</strong>.</li>
+<li>Confirm by clicking <strong>Delete</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open Instagram → tap your <strong>profile picture</strong> (bottom right).</li>
+<li>Tap the <strong>post</strong> you want to remove.</li>
+<li>Tap the <strong>⋯</strong> (top right) → <strong>Delete</strong>.</li>
+<li>Tap <strong>Delete</strong> again to confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open Instagram → tap your <strong>profile picture</strong> (bottom right).</li>
+<li>Open the <strong>post</strong> to remove.</li>
+<li>Tap <strong>⋯</strong> (top right) → <strong>Delete</strong>.</li>
+<li>Tap <strong>Delete</strong> again to confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-bulk-delete-multiple-posts">
+<h3>Bulk Delete Multiple Posts</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap the <strong>≡</strong> (menu) → <strong>Your activity</strong>.</li>
+<li>Tap <strong>Photos and videos</strong> → <strong>Posts</strong>.</li>
+<li>Tap <strong>Select</strong> (top right).</li>
+<li>Tap each post to remove.</li>
+<li>Tap <strong>Delete</strong> → <strong>Delete</strong> again to confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap the <strong>≡</strong> (menu) → <strong>Your activity</strong>.</li>
+<li>Tap <strong>Photos and videos</strong> → <strong>Posts</strong>.</li>
+<li>Tap <strong>Select</strong> (top right).</li>
+<li>Tap each post to remove.</li>
+<li>Tap <strong>Delete</strong> → <strong>Delete</strong> again to confirm.</li>
+</ol>
+</details>
+<p><em>Note: The web interface does not support native bulk deletion.</em></p>
+</section>
+<section class="card" id="guide-archive-a-post-instead-of-deleting">
+<h3>Archive a Post Instead of Deleting</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open your <strong>profile</strong> on <strong>instagram.com</strong>.</li>
+<li>Click the <strong>post</strong> to hide.</li>
+<li>Click <strong>⋯</strong> → <strong>Archive</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Archive</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Archive</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-restore-archived-posts">
+<h3>Restore Archived Posts</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong>.</li>
+<li>Tap <strong>Posts archive</strong>.</li>
+<li>Open the post → tap <strong>⋯</strong> → <strong>Show on profile</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong>.</li>
+<li>Tap <strong>Posts archive</strong>.</li>
+<li>Open the post → tap <strong>⋯</strong> → <strong>Show on profile</strong>.</li>
+</ol>
+</details>
+<p><em>Note: Archived posts are not accessible on the web interface.</em></p>
+</section>
+<section class="card" id="guide-delete-a-story-highlight">
+<h3>Delete a Story Highlight</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Click the <strong>highlight</strong> circle to remove.</li>
+<li>Click <strong>⋯</strong> → <strong>Delete highlight</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap and hold the <strong>highlight</strong>.</li>
+<li>Tap <strong>Delete highlight</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap and hold the <strong>highlight</strong>.</li>
+<li>Tap <strong>Delete highlight</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-a-single-story-from-a-highlight">
+<h3>Remove a Single Story from a Highlight</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap and hold the <strong>highlight</strong> → <strong>Edit highlight</strong>.</li>
+<li>Tap <strong>Stories</strong>.</li>
+<li>Uncheck the story to remove.</li>
+<li>Tap <strong>Done</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to your <strong>profile</strong>.</li>
+<li>Tap and hold the <strong>highlight</strong> → <strong>Edit highlight</strong>.</li>
+<li>Tap <strong>Stories</strong>.</li>
+<li>Uncheck the story to remove.</li>
+<li>Tap <strong>Done</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-a-reel">
+<h3>Delete a Reel</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> and open the <strong>Reel</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Delete</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → tap the <strong>Reels</strong> tab.</li>
+<li>Open the <strong>Reel</strong> → tap <strong>⋯</strong> → <strong>Delete</strong> → <strong>Delete</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → open the <strong>Reels</strong> tab.</li>
+<li>Open the <strong>Reel</strong> → tap <strong>⋯</strong> → <strong>Delete</strong> → <strong>Delete</strong> again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-yourself-from-a-tagged-photo">
+<h3>Remove Yourself from a Tagged Photo</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → click the <strong>Tagged</strong> tab.</li>
+<li>Open the photo.</li>
+<li>Click <strong>⋯</strong> → <strong>Tag options</strong> → <strong>Remove me from post</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>Tagged</strong> tab → open the photo.</li>
+<li>Tap <strong>⋯</strong> → <strong>Tag options</strong> → <strong>Remove me from post</strong>.</li>
+<li>Tap <strong>Remove</strong> to confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>Tagged</strong> tab → open the photo.</li>
+<li>Tap <strong>⋯</strong> → <strong>Tag options</strong> → <strong>Remove me from post</strong>.</li>
+<li>Tap <strong>Remove</strong> to confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-review-and-remove-all-tagged-photos">
+<h3>Review and Remove All Tagged Photos</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Profile → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Photos and videos</strong> → <strong>Tagged</strong>.</li>
+<li>Tap <strong>Select</strong>.</li>
+<li>Select each tagged post to leave.</li>
+<li>Tap <strong>Remove me</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Photos and videos</strong> → <strong>Tagged</strong>.</li>
+<li>Tap <strong>Select</strong>.</li>
+<li>Tap each tagged post to remove yourself.</li>
+<li>Tap <strong>Remove me</strong> → confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-a-comment-you-made">
+<h3>Delete a Comment You Made</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open the <strong>post</strong> containing your comment.</li>
+<li>Hover over your <strong>comment</strong>.</li>
+<li>Click the <strong>trash can</strong> icon → confirm <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open the <strong>post</strong> → find your <strong>comment</strong>.</li>
+<li>Tap and hold the comment → tap <strong>Delete</strong>.</li>
+<li>Tap <strong>Delete</strong> again if prompted.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open the <strong>post</strong> → locate your <strong>comment</strong>.</li>
+<li>Tap and hold the comment → tap <strong>Delete</strong>.</li>
+<li>Tap <strong>Delete</strong> again to confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-comments-on-your-post">
+<h3>Delete Comments on Your Post</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open your <strong>post</strong>.</li>
+<li>Hover over a <strong>comment</strong> → click the <strong>trash can</strong> icon.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open your <strong>post</strong>.</li>
+<li>Tap and hold a <strong>comment</strong> → tap the <strong>trash can</strong> icon.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open your <strong>post</strong>.</li>
+<li>Swipe left on the <strong>comment</strong> → tap the <strong>trash can</strong> icon.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-commenting-on-a-post">
+<h3>Turn Off Commenting on a Post</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Turn off commenting</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Turn off commenting</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Turn off commenting</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-hide-offensive-comments-automatically">
+<h3>Hide Offensive Comments Automatically</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Turn on <strong>Offensive words and phrases</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Toggle <strong>Offensive words and phrases</strong> <strong>ON</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Toggle <strong>Offensive words and phrases</strong> <strong>ON</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-a-follower-without-blocking">
+<h3>Remove a Follower Without Blocking</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → click <strong>Followers</strong>.</li>
+<li>Click <strong>Remove</strong> next to the person → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Profile → tap <strong>Followers</strong>.</li>
+<li>Tap <strong>Remove</strong> beside the account → tap <strong>Remove</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → tap <strong>Followers</strong>.</li>
+<li>Tap <strong>Remove</strong> beside the account → tap <strong>Remove</strong> again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-block-a-user">
+<h3>Block a User</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Visit the person’s <strong>profile</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Block</strong> → <strong>Block</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Block</strong> → <strong>Block</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Block</strong> → <strong>Block</strong> again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-unblock-a-user">
+<h3>Unblock a User</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to the person’s <strong>profile</strong>.</li>
+<li>Click <strong>Unblock</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Search for their <strong>profile</strong>.</li>
+<li>Tap <strong>Unblock</strong> → <strong>Unblock</strong> again.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Search for their <strong>profile</strong>.</li>
+<li>Tap <strong>Unblock</strong> → <strong>Unblock</strong> again.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-restrict-a-user">
+<h3>Restrict a User</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Visit their <strong>profile</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Restrict</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Restrict</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Restrict</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-mute-a-user">
+<h3>Mute a User</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Visit their <strong>profile</strong>.</li>
+<li>Tap <strong>Following</strong> → <strong>Mute</strong>.</li>
+<li>Toggle <strong>Posts</strong>, <strong>Stories</strong>, or both.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Visit their <strong>profile</strong>.</li>
+<li>Tap <strong>Following</strong> → <strong>Mute</strong>.</li>
+<li>Toggle <strong>Posts</strong>, <strong>Stories</strong>, or both.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-report-a-post">
+<h3>Report a Post</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Report</strong>.</li>
+<li>Choose a reason and follow the prompts.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Report</strong>.</li>
+<li>Follow the instructions.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open the <strong>post</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Report</strong>.</li>
+<li>Follow the instructions.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-report-a-user">
+<h3>Report a User</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Visit their <strong>profile</strong>.</li>
+<li>Click <strong>⋯</strong> → <strong>Report user</strong>.</li>
+<li>Follow the prompts.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Go to their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Report</strong>.</li>
+<li>Choose a reason and follow the instructions.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to their <strong>profile</strong>.</li>
+<li>Tap <strong>⋯</strong> → <strong>Report</strong>.</li>
+<li>Choose a reason and follow the instructions.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-clear-search-history">
+<h3>Clear Search History</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click the <strong>Search</strong> bar.</li>
+<li>Click <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon.</li>
+<li>Tap the <strong>search bar</strong> → <strong>See all</strong>.</li>
+<li>Tap <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon.</li>
+<li>Tap the <strong>search bar</strong> → <strong>See all</strong>.</li>
+<li>Tap <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-clear-suggested-accounts">
+<h3>Clear Suggested Accounts</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> bar.</li>
+<li>Tap <strong>See all</strong> under suggestions.</li>
+<li>Tap the <strong>X</strong> next to any suggestion.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> bar.</li>
+<li>Tap <strong>See all</strong> below suggestions.</li>
+<li>Tap the <strong>X</strong> beside any suggestion.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-disconnect-an-app-from-instagram">
+<h3>Disconnect an App from Instagram</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Apps and websites</strong>.</li>
+<li>Click <strong>Remove</strong> next to the app.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Apps and websites</strong>.</li>
+<li>Tap <strong>Remove</strong> beside the app.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Apps and websites</strong>.</li>
+<li>Tap <strong>Remove</strong> next to the app.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-download-your-account-data">
+<h3>Download Your Account Data</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Click <strong>Download your information</strong>.</li>
+<li>Choose the format and click <strong>Request download</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Tap <strong>Download your information</strong>.</li>
+<li>Set the options → tap <strong>Request download</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Tap <strong>Download your information</strong>.</li>
+<li>Choose the options → tap <strong>Request download</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-your-account-permanently">
+<h3>Delete Your Account Permanently</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Visit <a href="https://www.instagram.com/accounts/remove/request/permanent/" rel="nofollow">instagram.com/accounts/remove/request/permanent/</a>.</li>
+<li>Sign in → select a reason → enter your password.</li>
+<li>Click <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Personal details</strong>.</li>
+<li>Tap <strong>Account ownership and control</strong> → <strong>Deactivation or deletion</strong>.</li>
+<li>Select <strong>Delete account</strong> → follow the prompts.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Personal details</strong>.</li>
+<li>Tap <strong>Account ownership and control</strong> → <strong>Deactivation or deletion</strong>.</li>
+<li>Select <strong>Delete account</strong> → follow the prompts.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-deactivate-your-account-temporarily">
+<h3>Deactivate Your Account Temporarily</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open <strong>Edit profile</strong>.</li>
+<li>Scroll down → click <strong>Temporarily deactivate my account</strong>.</li>
+<li>Select a reason → enter your password → click <strong>Temporarily deactivate</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open Instagram in a <strong>mobile browser</strong>.</li>
+<li>Sign in → go to <strong>Edit profile</strong>.</li>
+<li>Scroll down → tap <strong>Temporarily deactivate my account</strong> → follow the same steps as on web.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open a <strong>mobile browser</strong> and sign in to Instagram.</li>
+<li>Go to <strong>Edit profile</strong>.</li>
+<li>Scroll down → tap <strong>Temporarily deactivate my account</strong> → follow the web prompts.</li>
+</ol>
+</details>
+<p><em>Note: Temporary deactivation is not available inside the Instagram app.</em></p>
+</section>
+<section class="card" id="guide-remove-a-saved-post">
+<h3>Remove a Saved Post</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click <strong>Saved</strong> (bookmark icon).</li>
+<li>Open the post → click <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong>.</li>
+<li>Tap <strong>⋯</strong> on the post → <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong>.</li>
+<li>Tap <strong>⋯</strong> on the post → <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-a-message-thread">
+<h3>Delete a Message Thread</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click the <strong>Messages</strong> icon.</li>
+<li>Hover over the thread → click <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap the <strong>Messenger</strong> icon.</li>
+<li>Tap and hold (or swipe left) on the thread → tap <strong>Delete</strong>.</li>
+<li>Confirm the deletion.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap the <strong>Messenger</strong> icon.</li>
+<li>Swipe left on the thread → tap <strong>Delete</strong>.</li>
+<li>Confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-a-single-message">
+<h3>Delete a Single Message</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open the <strong>chat</strong>.</li>
+<li>Hover over the message → click <strong>⋯</strong> → <strong>Unsend</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open the <strong>chat</strong>.</li>
+<li>Tap and hold the message → tap <strong>Unsend</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open the <strong>chat</strong>.</li>
+<li>Tap and hold the message → tap <strong>Unsend</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-log-out-of-all-devices">
+<h3>Log Out of All Devices</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Click <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Click <strong>Log out of all devices</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Tap <strong>Where you’re logged in</strong> → <strong>Log out of all devices</strong>.</li>
+<li>Confirm the log out.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Tap <strong>Where you’re logged in</strong> → <strong>Log out of all devices</strong>.</li>
+<li>Confirm.</li>
+</ol>
+</details>
+</section>
 </div>
 <aside aria-label="On this page" class="platform-sidebar">
 <div class="card toc-card">
@@ -2074,6 +2854,7 @@
 <li><a href="#range-1-15">Guides #1–15</a></li>
 <li><a href="#range-16-30">Guides #16–30</a></li>
 <li><a href="#range-31-60">Guides #31–60</a></li>
+<li><a href="#range-61-90">Guides #61–90</a></li>
 </ul>
 </nav>
 </div>


### PR DESCRIPTION
## Summary
- add Instagram guides #61-90 focused on cleanup, removal, and account control workflows
- extend the Instagram guide index and sidebar navigation to include the new batch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a9aa386883238c0a9aa3ed6178a2