### PR TITLE
Add Instagram guides batch 4 (91–120)

### DIFF
--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -172,6 +172,37 @@
 <li><a href="#guide-delete-a-message-thread">Delete a Message Thread</a></li>
 <li><a href="#guide-delete-a-single-message">Delete a Single Message</a></li>
 <li><a href="#guide-log-out-of-all-devices">Log Out of All Devices</a></li>
+<li class="guide-range-divider"><span>Guides #91–120</span></li>
+<li><a href="#guide-disconnect-instagram-from-search-engines">Disconnect Instagram from Search Engines</a></li>
+<li><a href="#guide-remove-synced-contacts-from-facebook-link">Remove Synced Contacts from Facebook Link</a></li>
+<li><a href="#guide-remove-synced-call-and-sms-logs">Remove Synced Call and SMS Logs (If Linked)</a></li>
+<li><a href="#guide-remove-your-likes-from-posts">Remove Your Likes from Posts</a></li>
+<li><a href="#guide-remove-all-saved-posts">Remove All Saved Posts</a></li>
+<li><a href="#guide-remove-specific-saved-posts">Remove Specific Saved Posts</a></li>
+<li><a href="#guide-delete-watch-history">Delete Watch History</a></li>
+<li><a href="#guide-delete-search-history-global-reset">Delete Search History (Global Reset)</a></li>
+<li><a href="#guide-remove-suggested-search-terms">Remove Suggested Search Terms</a></li>
+<li><a href="#guide-remove-old-stories-from-archive">Remove Old Stories from Archive</a></li>
+<li><a href="#guide-delete-archived-reels">Delete Archived Reels</a></li>
+<li><a href="#guide-delete-archived-live-videos">Delete Archived Live Videos</a></li>
+<li><a href="#guide-delete-story-drafts">Delete Story Drafts</a></li>
+<li><a href="#guide-delete-reel-drafts">Delete Reel Drafts</a></li>
+<li><a href="#guide-remove-devices-from-login-list">Remove Devices from Login List</a></li>
+<li><a href="#guide-revoke-active-sessions-individually">Revoke Active Sessions Individually</a></li>
+<li><a href="#guide-turn-off-location-access">Turn Off Location Access for Instagram</a></li>
+<li><a href="#guide-turn-off-camera-access">Turn Off Camera Access for Instagram</a></li>
+<li><a href="#guide-turn-off-microphone-access">Turn Off Microphone Access</a></li>
+<li><a href="#guide-turn-off-photo-media-access">Turn Off Photo/Media Library Access</a></li>
+<li><a href="#guide-disable-background-app-refresh">Disable Background App Refresh</a></li>
+<li><a href="#guide-turn-off-app-tracking-ios">Turn Off App Tracking (iOS)</a></li>
+<li><a href="#guide-review-advertisers-youve-interacted-with">Review Advertisers You’ve Interacted With</a></li>
+<li><a href="#guide-turn-off-interest-based-ads">Turn Off Interest-Based Ads</a></li>
+<li><a href="#guide-turn-off-ads-based-on-meta-activity">Turn Off Ads Based on Your Activity on Meta</a></li>
+<li><a href="#guide-turn-off-audience-expansion">Turn Off Audience Expansion for Ads</a></li>
+<li><a href="#guide-opt-out-sensitive-ad-topics">Opt Out of Sensitive Ad Topics</a></li>
+<li><a href="#guide-clear-instagram-cache-android">Clear Instagram Cache (Android)</a></li>
+<li><a href="#guide-revoke-access-connected-websites">Revoke Access for All Connected Websites</a></li>
+<li><a href="#guide-delete-instagram-data-export-file">Delete Your Instagram Data Export File (After Download)</a></li>
 </ol>
 </nav>
 <h2 class="guide-range-heading" id="range-1-15">Guides #1–15</h2>
@@ -2843,6 +2874,611 @@
 </ol>
 </details>
 </section>
+<h2 class="guide-range-heading" id="range-91-120">Guides #91–120</h2>
+<section class="card" id="guide-disconnect-instagram-from-search-engines">
+<h3>Disconnect Instagram from Search Engines</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to your <strong>profile</strong> on <strong>instagram.com</strong>.</li>
+<li>Click <strong>Edit profile</strong>.</li>
+<li>Scroll down and uncheck <strong>Allow search engines outside of Instagram to link to your profile</strong>.</li>
+<li>Click <strong>Submit</strong>.</li>
+</ol>
+</details>
+<p><em>Note: This setting is only available from the web interface.</em></p>
+</section>
+<section class="card" id="guide-remove-synced-contacts-from-facebook-link">
+<h3>Remove Synced Contacts from Facebook Link</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Select <strong>Contacts syncing</strong>.</li>
+<li>Click <strong>Manage contacts</strong> → <strong>Delete all contacts</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong> → <strong>Contacts syncing</strong>.</li>
+<li>Tap <strong>Manage contacts</strong> → <strong>Delete all contacts</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong> → <strong>Contacts syncing</strong>.</li>
+<li>Tap <strong>Manage contacts</strong> → <strong>Delete all contacts</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-synced-call-and-sms-logs">
+<h3>Remove Synced Call and SMS Logs (If Linked)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Choose <strong>Phone and SMS syncing</strong>.</li>
+<li>Turn the toggle <strong>Off</strong> and click <strong>Delete data</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Phone and SMS syncing</strong>.</li>
+<li>Turn off the toggle, then tap <strong>Delete data</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Phone and SMS syncing</strong>.</li>
+<li>Turn off the toggle and tap <strong>Delete data</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-your-likes-from-posts">
+<h3>Remove Your Likes from Posts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to <strong>Profile</strong> → <strong>Your activity</strong> → <strong>Interactions</strong> → <strong>Likes</strong>.</li>
+<li>Click <strong>Unlike</strong> next to any post you want to remove.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open your <strong>profile</strong> → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Interactions</strong> → <strong>Likes</strong>.</li>
+<li>Tap <strong>Select</strong> → choose posts → tap <strong>Unlike</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Interactions</strong> → <strong>Likes</strong>.</li>
+<li>Tap <strong>Select</strong>, pick the posts, then tap <strong>Unlike</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-all-saved-posts">
+<h3>Remove All Saved Posts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click the <strong>bookmark</strong> icon → <strong>Saved</strong>.</li>
+<li>Open each collection → click <strong>⋯</strong> → <strong>Delete collection</strong>.</li>
+<li>Confirm the deletion.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong>.</li>
+<li>Open a collection → tap <strong>⋯</strong> → <strong>Delete collection</strong>.</li>
+<li>Repeat for every collection.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong>.</li>
+<li>Enter a collection → tap <strong>⋯</strong> → <strong>Delete collection</strong>.</li>
+<li>Confirm and repeat for remaining collections.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-specific-saved-posts">
+<h3>Remove Specific Saved Posts</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click <strong>Saved</strong> → open the collection that contains the post.</li>
+<li>Click <strong>⋯</strong> on the post → <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong> → choose the collection.</li>
+<li>Tap <strong>⋯</strong> on the post → <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>≡</strong> → <strong>Saved</strong> → open the collection.</li>
+<li>Tap <strong>⋯</strong> on the post → <strong>Remove from saved</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-watch-history">
+<h3>Delete Watch History</h3>
+<p class="lead">Instagram only exposes watch-history controls in the mobile apps.</p>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Videos you’ve watched</strong>.</li>
+<li>Tap <strong>Select all</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open your <strong>profile</strong> → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Videos you’ve watched</strong>.</li>
+<li>Tap <strong>Select all</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<p><em>Note: Watch history deletion is not currently available on the web.</em></p>
+</section>
+<section class="card" id="guide-delete-search-history-global-reset">
+<h3>Delete Search History (Global Reset)</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Click the <strong>Search</strong> icon.</li>
+<li>Choose <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon → tap the <strong>search bar</strong>.</li>
+<li>Select <strong>See all</strong> → tap <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon → tap the <strong>search bar</strong>.</li>
+<li>Tap <strong>See all</strong> → <strong>Clear all</strong> → confirm.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-suggested-search-terms">
+<h3>Remove Suggested Search Terms</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon → the <strong>search bar</strong>.</li>
+<li>Tap the <strong>X</strong> next to any suggestion you want gone.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap the <strong>Search</strong> icon → the <strong>search bar</strong>.</li>
+<li>Tap the <strong>X</strong> beside the suggestion you wish to remove.</li>
+</ol>
+</details>
+<p><em>Note: Suggested search cleanup is only available in the mobile apps.</em></p>
+</section>
+<section class="card" id="guide-remove-old-stories-from-archive">
+<h3>Remove Old Stories from Archive</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Go to your <strong>profile</strong> → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Stories</strong>.</li>
+<li>Open the story → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → tap <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Stories</strong>.</li>
+<li>Open the story → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-archived-reels">
+<h3>Delete Archived Reels</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Reels</strong>.</li>
+<li>Select the reel → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Reels</strong>.</li>
+<li>Open the reel → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-archived-live-videos">
+<h3>Delete Archived Live Videos</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Live</strong>.</li>
+<li>Choose the live video → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Profile → <strong>≡</strong> → <strong>Your activity</strong> → <strong>Archived</strong> → <strong>Live</strong>.</li>
+<li>Select the video → tap <strong>⋯</strong> → <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-story-drafts">
+<h3>Delete Story Drafts</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>+</strong> → <strong>Story</strong>.</li>
+<li>Select <strong>Drafts</strong> → tap <strong>Select</strong>.</li>
+<li>Choose drafts → tap <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>+</strong> → <strong>Story</strong>.</li>
+<li>Open <strong>Drafts</strong> → tap <strong>Select</strong>.</li>
+<li>Pick drafts → tap <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-reel-drafts">
+<h3>Delete Reel Drafts</h3>
+<details open>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>+</strong> → <strong>Reel</strong>.</li>
+<li>Tap <strong>Drafts</strong> → <strong>Select</strong>.</li>
+<li>Choose the drafts → tap <strong>Delete</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Tap <strong>+</strong> → <strong>Reel</strong>.</li>
+<li>Open <strong>Drafts</strong> → tap <strong>Select</strong>.</li>
+<li>Select drafts → tap <strong>Delete</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-remove-devices-from-login-list">
+<h3>Remove Devices from Login List</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Select <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Click a device → <strong>Log out</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Open <strong>Where you’re logged in</strong>.</li>
+<li>Tap a device → <strong>Log out</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Enter <strong>Where you’re logged in</strong>.</li>
+<li>Tap a device → <strong>Log out</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-revoke-active-sessions-individually">
+<h3>Revoke Active Sessions Individually</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
+<li>Click the session you want to end → <strong>Log out</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Tap <strong>Where you’re logged in</strong> → choose the session → <strong>Log out</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Tap <strong>Where you’re logged in</strong> → select the session → <strong>Log out</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-location-access">
+<h3>Turn Off Location Access for Instagram</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Open the device <strong>Settings</strong> app.</li>
+<li>Tap <strong>Apps</strong> → <strong>Instagram</strong> → <strong>Permissions</strong>.</li>
+<li>Select <strong>Location</strong> → choose <strong>Deny</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Instagram</strong>.</li>
+<li>Tap <strong>Location</strong> → choose <strong>Never</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-camera-access">
+<h3>Turn Off Camera Access for Instagram</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Go to <strong>Settings</strong> → <strong>Apps</strong> → <strong>Instagram</strong> → <strong>Permissions</strong>.</li>
+<li>Tap <strong>Camera</strong> → select <strong>Deny</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Instagram</strong>.</li>
+<li>Toggle <strong>Camera</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-microphone-access">
+<h3>Turn Off Microphone Access</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Apps</strong> → <strong>Instagram</strong> → <strong>Permissions</strong>.</li>
+<li>Tap <strong>Microphone</strong> → choose <strong>Deny</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Instagram</strong>.</li>
+<li>Toggle <strong>Microphone</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-photo-media-access">
+<h3>Turn Off Photo/Media Library Access</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Open device <strong>Settings</strong> → <strong>Apps</strong> → <strong>Instagram</strong> → <strong>Permissions</strong>.</li>
+<li>Tap <strong>Photos and media</strong> → choose <strong>Deny</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS</summary>
+<ol>
+<li>Go to <strong>Settings</strong> → <strong>Instagram</strong>.</li>
+<li>Tap <strong>Photos</strong> → choose <strong>None</strong> or <strong>Selected photos</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-disable-background-app-refresh">
+<h3>Disable Background App Refresh</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Apps</strong> → <strong>Instagram</strong>.</li>
+<li>Tap <strong>Mobile data and Wi-Fi</strong>.</li>
+<li>Turn <strong>Background data</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>General</strong> → <strong>Background App Refresh</strong>.</li>
+<li>Toggle <strong>Instagram</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-app-tracking-ios">
+<h3>Turn Off App Tracking (iOS)</h3>
+<details open>
+<summary>iOS</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Privacy &amp; Security</strong> → <strong>Tracking</strong>.</li>
+<li>Turn <strong>Allow Apps to Request to Track</strong> <strong>Off</strong>.</li>
+<li>If listed, toggle <strong>Instagram</strong> <strong>Off</strong> individually.</li>
+</ol>
+</details>
+<p><em>Note: Android handles ad tracking controls differently; follow device-level privacy settings separately.</em></p>
+</section>
+<section class="card" id="guide-review-advertisers-youve-interacted-with">
+<h3>Review Advertisers You’ve Interacted With</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Advertisers</strong>.</li>
+<li>Review the list and remove any advertiser you no longer want associated.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Advertisers</strong>.</li>
+<li>Remove advertisers you don’t want tracking you.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Advertisers</strong>.</li>
+<li>Remove unwanted advertisers.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-interest-based-ads">
+<h3>Turn Off Interest-Based Ads</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Ad settings</strong>.</li>
+<li>Turn <strong>Use activity from partners</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Open <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Ad settings</strong>.</li>
+<li>Toggle <strong>Use activity from partners</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to <strong>Accounts Center</strong> → <strong>Ad preferences</strong> → <strong>Ad settings</strong>.</li>
+<li>Turn <strong>Use activity from partners</strong> <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-ads-based-on-meta-activity">
+<h3>Turn Off Ads Based on Your Activity on Meta</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>From <strong>Ad settings</strong>, open <strong>Show ads based on activity on Meta products</strong>.</li>
+<li>Set the option to <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>In <strong>Ad settings</strong>, tap <strong>Show ads based on activity on Meta products</strong>.</li>
+<li>Select <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Within <strong>Ad settings</strong>, open <strong>Show ads based on activity on Meta products</strong>.</li>
+<li>Choose <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-turn-off-audience-expansion">
+<h3>Turn Off Audience Expansion for Ads</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>In <strong>Ad settings</strong>, open <strong>Audience expansion</strong>.</li>
+<li>Set it to <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Go to <strong>Ad settings</strong> → <strong>Audience expansion</strong>.</li>
+<li>Turn the setting <strong>Off</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open <strong>Ad settings</strong> → <strong>Audience expansion</strong>.</li>
+<li>Disable it by choosing <strong>Off</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-opt-out-sensitive-ad-topics">
+<h3>Opt Out of Sensitive Ad Topics</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Open <strong>Ad preferences</strong> → <strong>Ad topics</strong>.</li>
+<li>Select a topic → choose <strong>Show less</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>Ad preferences</strong> → <strong>Ad topics</strong>.</li>
+<li>Choose topics you want to limit → tap <strong>Show less</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Go to <strong>Ad preferences</strong> → <strong>Ad topics</strong>.</li>
+<li>Select the topics → tap <strong>Show less</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-clear-instagram-cache-android">
+<h3>Clear Instagram Cache (Android)</h3>
+<details open>
+<summary>Android</summary>
+<ol>
+<li>Open <strong>Settings</strong> → <strong>Apps</strong> → <strong>Instagram</strong>.</li>
+<li>Tap <strong>Storage</strong> → <strong>Clear cache</strong>.</li>
+</ol>
+</details>
+<p><em>Note: iOS requires deleting and reinstalling the app to clear cached data.</em></p>
+</section>
+<section class="card" id="guide-revoke-access-connected-websites">
+<h3>Revoke Access for All Connected Websites</h3>
+<details open>
+<summary>Web (browser)</summary>
+<ol>
+<li>Go to <strong>Accounts Center</strong> → <strong>Apps and websites</strong>.</li>
+<li>Open <strong>Active</strong> → click <strong>Remove all</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>Android app</summary>
+<ol>
+<li>Tap <strong>Accounts Center</strong> → <strong>Apps and websites</strong>.</li>
+<li>Select <strong>Active</strong> → tap <strong>Remove all</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>iOS app</summary>
+<ol>
+<li>Open <strong>Accounts Center</strong> → <strong>Apps and websites</strong>.</li>
+<li>Tap <strong>Active</strong> → <strong>Remove all</strong>.</li>
+</ol>
+</details>
+</section>
+<section class="card" id="guide-delete-instagram-data-export-file">
+<h3>Delete Your Instagram Data Export File (After Download)</h3>
+<details open>
+<summary>All platforms</summary>
+<ol>
+<li>Locate the downloaded Instagram data export ZIP in your <strong>Downloads</strong> or <strong>Files</strong> folder.</li>
+<li>Delete the file from your device.</li>
+<li>Empty your <strong>Recycle Bin/Trash</strong> if applicable to remove it permanently.</li>
+</ol>
+</details>
+</section>
 </div>
 <aside aria-label="On this page" class="platform-sidebar">
 <div class="card toc-card">
@@ -2855,6 +3491,7 @@
 <li><a href="#range-16-30">Guides #16–30</a></li>
 <li><a href="#range-31-60">Guides #31–60</a></li>
 <li><a href="#range-61-90">Guides #61–90</a></li>
+<li><a href="#range-91-120">Guides #91–120</a></li>
 </ul>
 </nav>
 </div>


### PR DESCRIPTION
## Summary
- add the final Instagram guides covering actions #91–120 for data cleanup, permissions, and ad/privacy controls
- extend the guide index and sidebar navigation to link to the new range

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4abdb9ec08323a73ec756ee3684bd