### PR TITLE
Add Instagram backup reset and sharing guidance

### DIFF
--- a/platforms/instagram.html
+++ b/platforms/instagram.html
@@ -62,8 +62,8 @@
 <h3>Mobile (Instagram app)</h3>
 <ul>
 <li><strong>Profile tab:</strong> Bottom-right circle icon. Tap it to open your profile.</li>
-<li><strong>Menu (☰):</strong> Top-right of your profile. Tap to open <strong>Settings &amp; privacy</strong>.</li>
-<li><strong>Accounts Center:</strong> Lives at the top of <strong>Settings &amp; privacy</strong>. Use it for password, login, and cross-app controls.</li>
+<li><strong>Menu (☰):</strong> Top-right of your profile. Tap to open <strong>Settings and privacy</strong>.</li>
+<li><strong>Accounts Center:</strong> Lives at the top of <strong>Settings and privacy</strong>. Use it for password, login, and cross-app controls.</li>
 <li><strong>Search bar:</strong> Within Settings, use the search field at the top to find features quickly.</li>
 </ul>
 <h3>Desktop (instagram.com)</h3>
@@ -84,6 +84,7 @@
 <li><a href="#guide-review-login-activity-log-out">Review Login Activity &amp; Log Out of Unknown Devices</a></li>
 <li><a href="#guide-change-password-enable-password-manager">Change Password &amp; Enable Password Manager</a></li>
 <li><a href="#guide-set-up-backup-codes-offline">Set Up Backup Codes (Offline)</a></li>
+<li><a href="#guide-reset-backup-codes">Reset Backup Codes</a></li>
 <li><a href="#guide-verify-email-phone-remove-old-recovery-info">Verify Email &amp; Phone, Remove Old Recovery Info</a></li>
 <li><a href="#guide-set-account-to-private">Set Account to Private</a></li>
 <li><a href="#guide-hide-activity-status">Hide Activity Status</a></li>
@@ -109,6 +110,7 @@
 <li><a href="#guide-limit-story-replies-to-close-friends">Limit Story Replies to Close Friends Only</a></li>
 <li><a href="#guide-quiet-mode-notification-controls">Quiet Mode / Notification Controls</a></li>
 <li><a href="#guide-download-your-information-export">Download Your Information (Export)</a></li>
+<li><a href="#guide-cancel-data-download-request">Cancel a Data Download Request</a></li>
 <li><a href="#guide-delete-search-history-and-suggested-results">Delete Search History &amp; Suggested Results</a></li>
 <li class="guide-range-divider"><span>Guides #31–60</span></li>
 <li><a href="#guide-unlink-facebook-threads-other-linked-accounts">Unlink Facebook / Threads / Other Linked Accounts</a></li>
@@ -117,8 +119,7 @@
 <li><a href="#guide-turn-off-cross-app-friend-suggestions-facebook-to-instagram">Turn Off Cross-App Friend Suggestions (Facebook → Instagram)</a></li>
 <li><a href="#guide-turn-off-similar-account-suggestions">Turn Off “Similar Account Suggestions”</a></li>
 <li><a href="#guide-turn-off-face-recognition-if-you-see-it">Turn Off Face Recognition (If You See It)</a></li>
-<li><a href="#guide-stop-automatically-sharing-stories-to-facebook">Stop Automatically Sharing Stories to Facebook</a></li>
-<li><a href="#guide-stop-automatically-sharing-posts-to-facebook">Stop Automatically Sharing Posts to Facebook</a></li>
+<li><a href="#guide-stop-automatic-sharing-to-facebook">Stop Automatic Sharing to Facebook (Stories / Posts / Reels)</a></li>
 <li><a href="#guide-turn-off-cross-app-interactions-story-reactions-from-facebook">Turn Off Cross-App Interactions (Story Reactions from Facebook)</a></li>
 <li><a href="#guide-hide-your-stories-from-specific-people">Hide Your Stories from Specific People</a></li>
 <li><a href="#guide-hide-your-reels-from-specific-people">Hide Your Reels from Specific People</a></li>
@@ -130,7 +131,6 @@
 <li><a href="#guide-limit-who-can-add-you-to-group-chats">Limit Who Can Add You to Group Chats</a></li>
 <li><a href="#guide-turn-on-limits-to-temporarily-restrict-new-interactions">Turn On “Limits” to Temporarily Restrict New Interactions</a></li>
 <li><a href="#guide-remove-specific-viewers-from-a-live-story-while-active">Remove Specific Viewers from a Live Story (While Active)</a></li>
-<li><a href="#guide-stop-automatically-sharing-reels-to-facebook">Stop Automatically Sharing Reels to Facebook</a></li>
 <li><a href="#guide-allow-only-emoji-story-replies">Allow Only Emoji Story Replies</a></li>
 <li><a href="#guide-require-approval-before-tagged-photos-appear">Require Approval Before Tagged Photos Appear</a></li>
 <li><a href="#guide-disable-remix-for-photos">Disable Remix for Photos</a></li>
@@ -214,7 +214,7 @@
 <summary>On Web</summary>
 <ol>
 <li>Go to your <strong>profile</strong> on <strong>instagram.com</strong> and click the <strong>Menu (☰)</strong>.</li>
-<li>Select <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
+<li>Select <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Password and security</strong>.</li>
 <li>Choose <strong>Two-factor authentication</strong> → pick <strong>Authentication app</strong> (recommended) → follow the code setup.</li>
 <li>Open <strong>Backup codes</strong>, copy the list, and save it offline (paper or secure password manager note).</li>
 <li>If menus shift, use the settings search bar and type <strong>"Two-factor"</strong>.</li>
@@ -223,7 +223,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Open Instagram → tap your <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open Instagram → tap your <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Enter the <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
 <li>Select <strong>Authentication app</strong> or <strong>Passkey</strong>, complete setup, and confirm.</li>
 <li>Back in 2FA, tap <strong>Backup codes</strong> → <strong>Get new codes</strong> → store them offline.</li>
@@ -233,7 +233,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
 <li>Choose <strong>Authentication app</strong> or <strong>Passkey</strong>, finish the pairing, then toggle on.</li>
 <li>Tap <strong>Backup codes</strong> → <strong>Get new codes</strong> → record them securely offline.</li>
@@ -250,7 +250,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Visit <strong>instagram.com</strong> → profile → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Visit <strong>instagram.com</strong> → profile → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Choose <strong>Security</strong> or <strong>Password and security</strong> → <strong>Emails from Instagram</strong>.</li>
 <li>Review the list of security emails sent in the past 14 days so you know what’s legitimate.</li>
 <li>If you see <strong>Login alerts</strong>, turn on email and push notifications for unrecognized logins.</li>
@@ -260,7 +260,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Notifications</strong> → <strong>Security</strong>.</li>
 <li>Enable alerts for <strong>Suspicious login attempts</strong> (email and push).</li>
 <li>Go back → under <strong>Security</strong>, open <strong>Emails from Instagram</strong> to confirm official messages.</li>
@@ -270,7 +270,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Open Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Open Instagram → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Select <strong>Notifications</strong> → <strong>Security</strong>.</li>
 <li>Toggle on alerts for unrecognized logins or suspicious login attempts.</li>
 <li>Under <strong>Security</strong>, tap <strong>Emails from Instagram</strong> to verify recent official communications.</li>
@@ -287,7 +287,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>From your profile menu on <strong>instagram.com</strong>, open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>From your profile menu on <strong>instagram.com</strong>, open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Go to <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
 <li>Click <strong>See all</strong> to expand the full device list.</li>
 <li>Select unfamiliar sessions and choose <strong>Log out</strong>.</li>
@@ -297,7 +297,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
 <li>Hit <strong>See all</strong>, inspect each device, and tap <strong>Log out</strong> for anything suspicious.</li>
 <li>After removing unknown sessions, change your password if needed.</li>
@@ -307,7 +307,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
 <li>Review the list, tapping <strong>See all</strong> to reveal older devices.</li>
 <li>Remove unknown sessions with <strong>Log out</strong>, then reset your password if anything looks off.</li>
@@ -324,7 +324,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu (☰)</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile → <strong>Menu (☰)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Select <strong>Password and security</strong> → <strong>Change password</strong>.</li>
 <li>Create a new password with at least 12 characters, mixing words, numbers, and symbols.</li>
 <li>Save it in your browser or dedicated password manager when prompted.</li>
@@ -334,7 +334,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Password and security</strong> → <strong>Change password</strong>.</li>
 <li>Enter your current password, then set a unique new one.</li>
 <li>Allow Google Password Manager to save the update when prompted.</li>
@@ -344,7 +344,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Open <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Change password</strong>.</li>
 <li>Enter a strong new password and confirm it.</li>
 <li>Save it in iCloud Keychain or your preferred password manager.</li>
@@ -361,7 +361,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Profile → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Go to <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
 <li>Open <strong>Backup codes</strong> → <strong>Get new codes</strong>.</li>
 <li>Download, copy, or print the codes and store them offline (not in screenshots on shared devices).</li>
@@ -371,7 +371,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Password and security</strong> → <strong>Two-factor authentication</strong> → <strong>Backup codes</strong>.</li>
 <li>Choose <strong>Get new codes</strong> and save them in a secure offline place.</li>
 <li>Consider copying them into an encrypted password manager note.</li>
@@ -381,7 +381,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Enter <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
 <li>Tap <strong>Backup codes</strong> → <strong>Get new codes</strong> and copy them somewhere offline.</li>
 <li>Store the codes in a secure note or physical safe.</li>
@@ -391,6 +391,44 @@
 <p><em>Notes: Treat codes like keys—keep them offline and rotate after using one.</em></p>
 <p><strong>Related terms:</strong> recovery codes, offline access.</p>
 </section>
+<section class="card" id="guide-reset-backup-codes">
+<h3>Reset Backup Codes</h3>
+<p class="lead"><strong>Why this matters:</strong> Resetting replaces old codes that may have leaked or been used.</p>
+<p><strong>What you’ll change:</strong> Generate a fresh set of single-use backup codes and invalidate the previous list.</p>
+<p class="settings-path"><strong>Path:</strong> Profile → Menu (≡) → Settings and privacy → Accounts Center → Password and security → Two-factor authentication → Backup codes.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Go to <strong>instagram.com</strong> → open your <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Select <strong>Accounts Center</strong> → <strong>Password and security</strong> → <strong>Two-factor authentication</strong>.</li>
+<li>Choose <strong>Backup codes</strong> → click <strong>Get new codes</strong> → acknowledge the warning.</li>
+<li>Download, copy, or print the fresh codes and store them offline.</li>
+<li>If menus shift, use the settings search for <strong>"backup codes"</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Password and security</strong> → <strong>Two-factor authentication</strong> → <strong>Backup codes</strong>.</li>
+<li>Hit <strong>Get new codes</strong> → accept the prompt to replace the existing codes.</li>
+<li>Save the regenerated list in a secure offline place.</li>
+<li>Search Settings for <strong>"backup"</strong> if the location moved.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Open <strong>Password and security</strong> → <strong>Two-factor authentication</strong> → <strong>Backup codes</strong>.</li>
+<li>Tap <strong>Get new codes</strong> and confirm you want to refresh them.</li>
+<li>Write the new codes down or store them in an encrypted password manager.</li>
+<li>Use Settings search for <strong>"two-factor"</strong> if needed.</li>
+</ol>
+</details>
+<p><strong>Confirm reset:</strong> Finish by tapping <strong>Done</strong> after the new codes appear so the old set is revoked.</p>
+<p><strong>Related terms:</strong> regenerate codes, refresh 2FA list, recovery reset.</p>
+</section>
 <section class="card" id="guide-verify-email-phone-remove-old-recovery-info">
 <h3>Verify Email &amp; Phone, Remove Old Recovery Info</h3>
 <p class="lead"><strong>Why this matters:</strong> Attackers often pivot via weak recovery channels.</p>
@@ -398,7 +436,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>On <strong>instagram.com</strong>, open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>On <strong>instagram.com</strong>, open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Choose <strong>Personal details</strong> → <strong>Contact info</strong>.</li>
 <li>Add or verify your current email and mobile number, removing any outdated entries.</li>
 <li>Check verification emails or texts to confirm ownership.</li>
@@ -408,7 +446,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Edit profile</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Edit profile</strong>.</li>
 <li>Tap <strong>Personal information</strong> (or go through <strong>Accounts Center</strong> → <strong>Personal details</strong>).</li>
 <li>Update your email and phone, verify them, and delete any old contact points.</li>
 <li>Ensure the recovery email you use has its own 2FA enabled.</li>
@@ -435,7 +473,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>From your profile on <strong>instagram.com</strong>, click <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>From your profile on <strong>instagram.com</strong>, click <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Go to <strong>Privacy and safety</strong> or <strong>Privacy</strong>.</li>
 <li>Select <strong>Account privacy</strong> → toggle <strong>Private account</strong> on.</li>
 <li>Confirm the change when prompted.</li>
@@ -445,7 +483,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Under <strong>Who can see your content</strong>, tap <strong>Account privacy</strong>.</li>
 <li>Toggle <strong>Private account</strong> on and confirm.</li>
 <li>Review your follower list afterward to remove any you don’t trust.</li>
@@ -455,7 +493,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Account privacy</strong>.</li>
 <li>Turn on <strong>Private account</strong> and confirm.</li>
 <li>Periodically audit existing followers since they keep access.</li>
@@ -472,7 +510,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> on <strong>instagram.com</strong> → <strong>Privacy</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> on <strong>instagram.com</strong> → <strong>Privacy</strong>.</li>
 <li>Choose <strong>Messages and story replies</strong> or <strong>Activity status</strong>.</li>
 <li>Toggle off <strong>Show activity status</strong> and any related “active together” options.</li>
 <li>Save changes if prompted.</li>
@@ -482,7 +520,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Privacy</strong> → <strong>Activity status</strong>.</li>
 <li>Turn off <strong>Show activity status</strong> and <strong>Show when you’re active together</strong>.</li>
 <li>Back out to save automatically.</li>
@@ -492,7 +530,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Select <strong>Activity status</strong>.</li>
 <li>Disable both toggles for sharing activity.</li>
 <li>Exit to save.</li>
@@ -509,7 +547,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>In <strong>Settings &amp; privacy</strong>, select <strong>Privacy</strong> → <strong>Mentions</strong>.</li>
+<li>In <strong>Settings and privacy</strong>, select <strong>Privacy</strong> → <strong>Mentions</strong>.</li>
 <li>Choose <strong>People you follow</strong> or <strong>No one</strong> to restrict mentions.</li>
 <li>Confirm the change.</li>
 <li>Review any pending mention requests if available.</li>
@@ -519,7 +557,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Mentions</strong>.</li>
 <li>Select <strong>People you follow</strong> or <strong>No one</strong>.</li>
 <li>Use the check mark to confirm if prompted.</li>
@@ -529,7 +567,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Open <strong>Privacy</strong> → <strong>Mentions</strong>.</li>
 <li>Choose <strong>People you follow</strong> or <strong>No one</strong> to limit tags.</li>
 <li>Exit to save automatically.</li>
@@ -546,7 +584,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
 <li>Enable <strong>Manually approve tags</strong>.</li>
 <li>Review the <strong>Tagged posts</strong> queue and approve or decline pending tags.</li>
 <li>Remove yourself from any unwanted tags already attached.</li>
@@ -556,7 +594,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Tags</strong>.</li>
 <li>Toggle <strong>Manually approve tags</strong> on, then review pending tagged posts.</li>
 <li>Use <strong>Remove me from post</strong> on any unwanted tag.</li>
@@ -566,7 +604,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Select <strong>Tags</strong>.</li>
 <li>Enable <strong>Manually approve tags</strong> and review the pending list.</li>
 <li>Remove yourself from existing tags you don’t want.</li>
@@ -583,7 +621,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Within <strong>Settings &amp; privacy</strong>, choose <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Within <strong>Settings and privacy</strong>, choose <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
 <li>Toggle on <strong>Hide comments</strong> and <strong>Advanced comment filtering</strong> (language may vary).</li>
 <li>Enable filters for <strong>Messages</strong> if available.</li>
 <li>Add custom words, phrases, or emojis in <strong>Custom words and phrases</strong> and apply them to comments and message requests.</li>
@@ -593,7 +631,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Hidden words</strong>.</li>
 <li>Enable <strong>Offensive words and phrases</strong> and <strong>Advanced comment filtering</strong>.</li>
 <li>Under <strong>Custom words and phrases</strong>, add your keyword list and apply it to both comments and message requests.</li>
@@ -603,7 +641,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Open <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
 <li>Activate built-in filters for offensive content and spam.</li>
 <li>Add your own blocked keywords and apply them to comments and DM requests.</li>
@@ -657,7 +695,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>In <strong>Settings &amp; privacy</strong>, select <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>In <strong>Settings and privacy</strong>, select <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Set your <strong>Viewers</strong> (Everyone, Followers, Close Friends, or hide specific people).</li>
 <li>Under <strong>Allow message replies</strong>, pick <strong>Off</strong> or <strong>Followers you follow back</strong>.</li>
 <li>Disable <strong>Allow sharing</strong> options if available.</li>
@@ -667,7 +705,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Story</strong>.</li>
 <li>Choose your audience (Hide story from…, Close Friends, Followers).</li>
 <li>Set <strong>Allow message replies</strong> to <strong>Off</strong> or <strong>Followers you follow back</strong>.</li>
@@ -677,7 +715,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Select <strong>Story</strong>.</li>
 <li>Adjust who sees your stories and manage the <strong>Hide story from…</strong> list.</li>
 <li>Set <strong>Allow message replies</strong> to your preferred audience.</li>
@@ -694,7 +732,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Toggle off <strong>Allow sharing to story</strong> and any <strong>Allow sharing</strong> to messages options.</li>
 <li>Check <strong>Reels and Remix</strong> settings (below on the page) to keep photos/videos from being remixed.</li>
 <li>Review highlights to ensure old stories aren’t publicly available.</li>
@@ -704,7 +742,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Story</strong>.</li>
 <li>Disable <strong>Allow sharing to story</strong> and <strong>Sharing to messages</strong>.</li>
 <li>Scroll to <strong>Reels and Remix</strong> to disable sharing/remix for your posts.</li>
@@ -714,7 +752,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Turn off <strong>Allow sharing</strong> options for stories and messages.</li>
 <li>Visit <strong>Reels and Remix</strong> to disable resharing of your photos/videos.</li>
 <li>Consider removing older stories from highlights if you no longer want them accessible.</li>
@@ -731,7 +769,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Within <strong>Settings &amp; privacy</strong>, choose <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li>Within <strong>Settings and privacy</strong>, choose <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
 <li>Toggle off <strong>Allow for photos</strong> and <strong>Allow for videos</strong>.</li>
 <li>Disable <strong>Download your reels</strong> if the option appears.</li>
 <li>Repeat per post via the <strong>…</strong> menu on a reel if you need exceptions.</li>
@@ -741,7 +779,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Reels and Remix</strong>.</li>
 <li>Turn off remixing for photos and videos and disable reel downloads.</li>
 <li>For individual reels, tap <strong>…</strong> → <strong>Turn off remixing</strong> if you want selective control.</li>
@@ -751,7 +789,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Select <strong>Reels and Remix</strong>.</li>
 <li>Disable remixes for your photos/videos and turn off reel downloads.</li>
 <li>Override per reel via the <strong>…</strong> menu if necessary.</li>
@@ -769,7 +807,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> or <strong>Account settings</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Suggested content</strong> or <strong>Account settings</strong>.</li>
 <li>Click <strong>Sensitive content control</strong>.</li>
 <li>Choose <strong>Less</strong> or <strong>Limit Even More</strong> (if offered) to reduce sensitive recommendations.</li>
 <li>Confirm your selection.</li>
@@ -779,7 +817,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Suggested content</strong> (or <strong>Account settings</strong> on some builds) → <strong>Sensitive content control</strong>.</li>
 <li>Select <strong>Less</strong> or <strong>Limit Even More</strong> to dial down sensitive material in Explore/Reels.</li>
 <li>Save your choice.</li>
@@ -789,7 +827,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Choose <strong>Suggested content</strong> → <strong>Sensitive content control</strong>.</li>
 <li>Set it to <strong>Less</strong> or <strong>Limit Even More</strong> to reduce sensitive recommendations.</li>
 <li>Confirm the new level.</li>
@@ -806,7 +844,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Posts</strong>.</li>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Posts</strong>.</li>
 <li>Toggle on <strong>Hide like and view counts</strong>.</li>
 <li>For individual posts, open the post → <strong>…</strong> → <strong>Hide like count</strong>.</li>
 <li>Repeat for reels if prompted.</li>
@@ -816,7 +854,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Tap <strong>Posts</strong>.</li>
 <li>Enable <strong>Hide like and view counts</strong>.</li>
 <li>Per post: tap <strong>…</strong> → <strong>Hide like count</strong>.</li>
@@ -826,7 +864,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Select <strong>Privacy</strong> → <strong>Posts</strong>.</li>
 <li>Toggle on <strong>Hide like and view counts</strong>.</li>
 <li>Adjust per post via <strong>…</strong> → <strong>Hide like count</strong> as desired.</li>
@@ -843,7 +881,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages and story replies</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages and story replies</strong>.</li>
 <li>Adjust each category (People on Instagram, Others) to <strong>Don’t receive requests</strong> or <strong>Message requests</strong>.</li>
 <li>Limit <strong>Group</strong> invitations to <strong>People you follow</strong>.</li>
 <li>Save changes.</li>
@@ -853,7 +891,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Messages and story replies</strong> → <strong>Message controls</strong>.</li>
 <li>For each category, set to <strong>Don’t receive requests</strong> or send to <strong>Message requests</strong>.</li>
 <li>Restrict group invites to people you follow.</li>
@@ -863,7 +901,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Choose <strong>Messages and story replies</strong> → <strong>Message controls</strong>.</li>
 <li>Customize who can message you and where requests land.</li>
 <li>Limit group invitations to people you follow to reduce spam.</li>
@@ -883,7 +921,7 @@
 <li>Visit the profile you want to manage.</li>
 <li>Click <strong>…</strong> → choose <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong>.</li>
 <li>Confirm the action.</li>
-<li>Manage lists via <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Limited interactions</strong>/<strong>Blocked accounts</strong>.</li>
+<li>Manage lists via <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Limited interactions</strong>/<strong>Blocked accounts</strong>.</li>
 <li>Search for <strong>"Blocked"</strong> if you need to adjust later.</li>
 </ol>
 </details>
@@ -892,7 +930,7 @@
 <ol>
 <li>Open the person’s profile → tap <strong>…</strong>.</li>
 <li>Select <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong> and confirm.</li>
-<li>To review, go to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Restricted accounts</strong>/<strong>Muted accounts</strong>/<strong>Blocked accounts</strong>.</li>
+<li>To review, go to <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Restricted accounts</strong>/<strong>Muted accounts</strong>/<strong>Blocked accounts</strong>.</li>
 <li>Adjust or remove entries as needed.</li>
 <li>Search Settings for <strong>"Restrict"</strong> if you can’t locate the lists.</li>
 </ol>
@@ -902,7 +940,7 @@
 <ol>
 <li>Navigate to the user’s profile → tap <strong>…</strong>.</li>
 <li>Choose <strong>Restrict</strong>, <strong>Mute</strong>, or <strong>Block</strong>, then confirm.</li>
-<li>Manage lists from <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → the relevant section (Limited interactions, Muted accounts, Blocked accounts).</li>
+<li>Manage lists from <strong>Settings and privacy</strong> → <strong>Privacy</strong> → the relevant section (Limited interactions, Muted accounts, Blocked accounts).</li>
 <li>Unrestrict or unblock from the same lists when needed.</li>
 <li>Use Settings search for <strong>"Blocked"</strong> if options move.</li>
 </ol>
@@ -917,7 +955,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Select <strong>Apps and websites</strong> or <strong>Logged in with Instagram</strong>.</li>
 <li>Under <strong>Active</strong>, click unwanted integrations and choose <strong>Remove</strong>.</li>
 <li>Repeat for the <strong>Expired</strong> list to clean up lingering access.</li>
@@ -927,7 +965,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Your information and permissions</strong> → <strong>Apps and websites</strong>.</li>
 <li>Review the <strong>Active</strong> tab, removing anything unfamiliar.</li>
 <li>Check <strong>Expired</strong> for leftovers and clear them as well.</li>
@@ -937,7 +975,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Select <strong>Your information and permissions</strong> → <strong>Apps and websites</strong>.</li>
 <li>Remove any integration you don’t recognize or no longer need.</li>
 <li>Repeat periodically to keep access tight.</li>
@@ -954,7 +992,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
 <li>Review <strong>Ad topics</strong> and mark sensitive ones as <strong>See less</strong>.</li>
 <li>Open <strong>Ad settings</strong> to disable <strong>Use of activity from partners</strong> and ads shown off Meta where possible.</li>
 <li>Check <strong>Categories used to reach you</strong> and remove anything you don’t like.</li>
@@ -964,7 +1002,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Ad preferences</strong>.</li>
 <li>Adjust <strong>Ad topics</strong>, <strong>Ad settings</strong>, and <strong>Categories used to reach you</strong>.</li>
 <li>Turn off partner activity usage where allowed.</li>
@@ -974,7 +1012,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Select <strong>Ad preferences</strong>.</li>
 <li>Limit sensitive topics and restrict partner data usage under <strong>Ad settings</strong>.</li>
 <li>Remove personal categories you disagree with.</li>
@@ -991,7 +1029,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Select <strong>Off-Meta activity</strong> (name may vary) → <strong>Manage</strong>.</li>
 <li>Clear history and choose to turn off future activity sharing if supported.</li>
 <li>Review connected businesses and remove ones you don’t trust.</li>
@@ -1001,7 +1039,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Your information and permissions</strong> → <strong>Off-Meta activity</strong> (or similar).</li>
 <li>Clear your history and disable future off-site activity sharing if available.</li>
 <li>Repeat periodically to keep partner data minimal.</li>
@@ -1011,7 +1049,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Choose <strong>Your information and permissions</strong> → <strong>Off-Meta activity</strong>.</li>
 <li>Clear past activity and opt out of future partner data collection where possible.</li>
 <li>Remove any specific partners you don’t recognize.</li>
@@ -1065,7 +1103,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Account</strong> or <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Account</strong> or <strong>Your information and permissions</strong>.</li>
 <li>Select <strong>Contacts syncing</strong> → toggle it off and delete previously uploaded contacts.</li>
 <li>Look for <strong>Discoverability</strong> or <strong>Suggesting your account</strong> and disable suggestions.</li>
 <li>Unlink Facebook in <strong>Accounts Center</strong> if you don’t want cross-recommendations.</li>
@@ -1075,7 +1113,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Tap <strong>Account</strong> → <strong>Contacts syncing</strong> → toggle off and remove synced contacts.</li>
 <li>Back out → open <strong>Your information and permissions</strong> → <strong>Suggesting your account on other apps</strong> (if shown) → turn off.</li>
 <li>Review Facebook connection under <strong>Accounts Center</strong> and unlink if not needed.</li>
@@ -1085,7 +1123,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong>.</li>
 <li>Choose <strong>Account</strong> → <strong>Contacts syncing</strong> → turn off syncing and delete uploaded contacts.</li>
 <li>Under <strong>Your information and permissions</strong>, disable discoverability or suggestions if available.</li>
 <li>Unlink Facebook in <strong>Accounts Center</strong> to stop cross-platform recommendations.</li>
@@ -1141,7 +1179,7 @@
 <ol>
 <li>Go to your profile → select the <strong>Tagged</strong> tab.</li>
 <li>Open each post where you’re tagged → click <strong>…</strong> → <strong>Remove me from post</strong>.</li>
-<li>Return to <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to confirm <strong>Manually approve tags</strong> is enabled.</li>
+<li>Return to <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to confirm <strong>Manually approve tags</strong> is enabled.</li>
 <li>Repeat until unwanted tags are cleared.</li>
 <li>Search for <strong>"Tagged"</strong> in Settings if you need quick access.</li>
 </ol>
@@ -1151,7 +1189,7 @@
 <ol>
 <li>Profile → <strong>Tagged</strong> tab → open a tagged post.</li>
 <li>Tap <strong>…</strong> → <strong>Remove me from post</strong>.</li>
-<li>Back in <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>, confirm <strong>Manually approve tags</strong> is on.</li>
+<li>Back in <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>, confirm <strong>Manually approve tags</strong> is on.</li>
 <li>Continue removing any other unwanted tags.</li>
 <li>Search Settings for <strong>"Tagged"</strong> if the tab is buried.</li>
 </ol>
@@ -1161,7 +1199,7 @@
 <ol>
 <li>Instagram app → <strong>profile</strong> → <strong>Tagged</strong>.</li>
 <li>Open a post → tap <strong>…</strong> → <strong>Remove me from post</strong>.</li>
-<li>Visit <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to ensure manual approval is active.</li>
+<li>Visit <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong> to ensure manual approval is active.</li>
 <li>Repeat as needed to clean up old tags.</li>
 <li>Use Settings search for <strong>"Tags"</strong> if the toggle has moved.</li>
 </ol>
@@ -1176,7 +1214,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Under <strong>Allow message replies</strong>, choose <strong>Close Friends</strong> or <strong>Off</strong>.</li>
 <li>Confirm the change.</li>
 <li>Adjust <strong>Hide story from…</strong> for additional exclusions if needed.</li>
@@ -1186,7 +1224,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Set <strong>Allow message replies</strong> to <strong>Close Friends</strong> or <strong>Off</strong>.</li>
 <li>Save and exit.</li>
 <li>Review your Close Friends list to ensure only trusted people can respond.</li>
@@ -1196,7 +1234,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Choose <strong>Close Friends</strong> under <strong>Allow message replies</strong>.</li>
 <li>Optionally hide the story from specific people for extra control.</li>
 <li>Exit to save.</li>
@@ -1213,7 +1251,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Notifications</strong>.</li>
 <li>Adjust categories like <strong>Messages</strong>, <strong>Comments</strong>, and <strong>Tags</strong> to reduce alerts.</li>
 <li>Set email and SMS notification preferences to the minimum you need.</li>
 <li>Repeat periodically to stay focused.</li>
@@ -1223,7 +1261,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Notifications</strong>.</li>
 <li>Tap <strong>Quiet mode</strong> → schedule start/end times.</li>
 <li>Adjust individual notification categories (Messages, Comments, Tags, Followers) to limit interruptions.</li>
 <li>Review push vs. email alerts to avoid duplicates.</li>
@@ -1233,7 +1271,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Notifications</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Notifications</strong>.</li>
 <li>Enable <strong>Quiet mode</strong> and set the schedule.</li>
 <li>Customize categories to limit DM, comment, and live notifications.</li>
 <li>Check email/SMS notification settings to reduce noise.</li>
@@ -1250,7 +1288,7 @@
 <details open>
 <summary>On Web</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Select <strong>Download your information</strong>.</li>
 <li>Choose Instagram, set the date range and format, and click <strong>Request a download</strong>.</li>
 <li>Wait for the email or in-app notification, then download securely.</li>
@@ -1260,7 +1298,7 @@
 <details>
 <summary>On Android</summary>
 <ol>
-<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Tap <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
 <li>Select Instagram, pick a date range and format, then tap <strong>Request a download</strong>.</li>
 <li>Use the link sent via email or in-app notification to retrieve the archive.</li>
@@ -1270,7 +1308,7 @@
 <details>
 <summary>On iOS</summary>
 <ol>
-<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Select <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
 <li>Choose Instagram, timeframe, and format, then submit the request.</li>
 <li>Download the archive once you receive the notification.</li>
@@ -1279,6 +1317,44 @@
 </details>
 <p><em>Notes: Store exports securely—they contain private messages, photos, and metadata.</em></p>
 <p><strong>Related terms:</strong> data portability, GDPR export.</p>
+</section>
+<section class="card" id="guide-cancel-data-download-request">
+<h3>Cancel a Data Download Request</h3>
+<p class="lead"><strong>Why this matters:</strong> You can stop a large export if you requested it by mistake or no longer need the archive.</p>
+<p><strong>What you’ll change:</strong> Withdraw any pending Instagram data download before it’s prepared or downloaded.</p>
+<p class="settings-path"><strong>Path:</strong> Profile → Menu (≡) → Settings and privacy → Accounts Center → Your information and permissions → Download your information.</p>
+<details open>
+<summary>On Web</summary>
+<ol>
+<li>Sign in at <strong>instagram.com</strong> → profile → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Click <strong>Accounts Center</strong> → <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
+<li>Under <strong>Available downloads</strong> or <strong>Pending</strong>, find the request you want to stop.</li>
+<li>Select <strong>Cancel download</strong> (or <strong>Delete request</strong>) and confirm when prompted.</li>
+<li>If you don’t see it, use the search bar for <strong>"download"</strong>.</li>
+</ol>
+</details>
+<details>
+<summary>On Android</summary>
+<ol>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
+<li>Scroll to <strong>Available downloads</strong> and pick the request.</li>
+<li>Hit <strong>Cancel download</strong> or <strong>Delete request</strong> → approve the confirmation.</li>
+<li>Use Settings search for <strong>"download"</strong> if the menu moved.</li>
+</ol>
+</details>
+<details>
+<summary>On iOS</summary>
+<ol>
+<li>Instagram → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Choose <strong>Your information and permissions</strong> → <strong>Download your information</strong>.</li>
+<li>Locate the pending export under <strong>Available downloads</strong>.</li>
+<li>Tap <strong>Cancel download</strong> → confirm to revoke the request.</li>
+<li>Search for <strong>"download"</strong> if you need to jump directly.</li>
+</ol>
+</details>
+<p><strong>Confirm cancel:</strong> The request disappears from <strong>Available downloads</strong> and you’ll no longer receive a link.</p>
+<p><strong>Related terms:</strong> revoke export, stop archive, cancel data request.</p>
 </section>
 <section class="card" id="guide-delete-search-history-and-suggested-results">
 <h3>Delete Search History &amp; Suggested Results</h3>
@@ -1289,7 +1365,7 @@
 <ol>
 <li>Click the <strong>Search</strong> icon → select the search bar.</li>
 <li>If <strong>Clear all</strong> appears, choose it to erase recent searches.</li>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to tune recommendations.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Suggested content</strong> to tune recommendations.</li>
 <li>Adjust preferences or mute topics you don’t want.</li>
 <li>Search for <strong>"Suggested content"</strong> if the menu changed.</li>
 </ol>
@@ -1299,7 +1375,7 @@
 <ol>
 <li>Tap <strong>Search</strong> → tap the bar → choose <strong>See all</strong>.</li>
 <li>Tap <strong>Clear all</strong> to remove recent searches.</li>
-<li>Go to <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to manage preferences.</li>
+<li>Go to <strong>Settings and privacy</strong> → <strong>Suggested content</strong> to manage preferences.</li>
 <li>Adjust categories or mute suggestions tied to past activity.</li>
 <li>Search Settings for <strong>"Suggested"</strong> if necessary.</li>
 </ol>
@@ -1309,7 +1385,7 @@
 <ol>
 <li>Open the <strong>Search</strong> tab → tap the search bar → tap <strong>See all</strong>.</li>
 <li>Select <strong>Clear all</strong> to wipe recent searches.</li>
-<li>Visit <strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> to refine what appears.</li>
+<li>Visit <strong>Settings and privacy</strong> → <strong>Suggested content</strong> to refine what appears.</li>
 <li>Mute or limit topics you don’t want recommended.</li>
 <li>Use Settings search for <strong>"Suggested"</strong> if the option has moved.</li>
 </ol>
@@ -1325,7 +1401,7 @@
 <ol>
 <li>Open Instagram and sign in.</li>
 <li>Click your <strong>profile picture</strong> (top right).</li>
-<li>Click <strong>Settings &amp; privacy</strong>.</li>
+<li>Click <strong>Settings and privacy</strong>.</li>
 <li>Scroll down and click <strong>Accounts Center</strong> (Meta window opens inside Instagram).</li>
 <li>In Accounts Center, click <strong>Connected experiences</strong>.</li>
 <li>Click <strong>Sharing across profiles</strong> or <strong>Connected profiles</strong>.</li>
@@ -1364,7 +1440,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile picture (top right) → <strong>Settings &amp; privacy</strong>.</li>
+<li>Profile picture (top right) → <strong>Settings and privacy</strong>.</li>
 <li>Click <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Login &amp; account settings</strong> (or <strong>Password and security</strong>).</li>
 <li>Turn <strong>Log in with Facebook</strong> <strong>OFF</strong> (if shown).</li>
@@ -1395,7 +1471,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile picture (top right) → <strong>Settings &amp; privacy</strong>.</li>
+<li>Profile picture (top right) → <strong>Settings and privacy</strong>.</li>
 <li>Click <strong>Account</strong> (or <strong>Your information and permissions</strong>).</li>
 <li>Click <strong>Contacts syncing</strong> → turn <strong>Sync contacts</strong> <strong>OFF</strong>.</li>
 <li>Click <strong>Manage contacts</strong> → <strong>Delete all contacts</strong> → confirm.</li>
@@ -1425,7 +1501,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile picture → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Connected experiences</strong>.</li>
 <li>Click <strong>Cross-app friends</strong> (or similar).</li>
 <li>Turn <strong>Friend suggestions</strong> <strong>OFF</strong>.</li>
@@ -1482,7 +1558,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong>.</li>
+<li>Profile picture → <strong>Settings and privacy</strong> → <strong>Privacy</strong>.</li>
 <li>Click <strong>Face recognition</strong>.</li>
 <li>Turn it <strong>OFF</strong>.</li>
 </ol>
@@ -1502,67 +1578,50 @@
 </ol>
 </details>
 </section>
-<section class="card" id="guide-stop-automatically-sharing-stories-to-facebook">
-<h3>Stop Automatically Sharing Stories to Facebook</h3>
+<section class="card" id="guide-stop-automatic-sharing-to-facebook">
+<h3>Stop Automatic Sharing to Facebook (Stories / Posts / Reels)</h3>
+<p class="lead"><strong>Why this matters:</strong> Automatic cross-posting can leak context to the wrong audience.</p>
+<p><strong>What you’ll change:</strong> Turn off Instagram’s auto-share toggles for Stories, Feed posts, and Reels so nothing publishes to Facebook without you choosing it.</p>
+<p class="settings-path"><strong>Path:</strong> Profile → Menu (≡) → Settings and privacy → Accounts Center → Sharing across profiles.</p>
 <details open>
-<summary>Web (browser)</summary>
+<summary>On Web</summary>
 <ol>
-<li>Profile picture → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li>Click <strong>Sharing across profiles</strong>.</li>
-<li>Click your <strong>Instagram → Facebook</strong> pairing.</li>
-<li>Click <strong>Story</strong> → turn <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+<li>On <strong>instagram.com</strong>, go to your <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Select <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong> → choose the <strong>Instagram → Facebook</strong> connection.</li>
+<li>Open <strong>Story</strong> → switch <strong>Automatically share</strong> to <strong>Off</strong>.</li>
+<li>Back out, open <strong>Feed</strong> → turn <strong>Automatically share</strong> <strong>Off</strong>.</li>
+<li>Repeat for <strong>Reels</strong>, ensuring each format now shows <strong>Off</strong>.</li>
+<li>If the layout shifts, search Settings for <strong>"sharing across"</strong> or <strong>"cross-post"</strong>.</li>
 </ol>
 </details>
 <details>
-<summary>Android app</summary>
+<summary>On Android</summary>
 <ol>
-<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li><strong>Sharing across profiles</strong> → pick <strong>Instagram → Facebook</strong>.</li>
-<li>Tap <strong>Story</strong> → toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+<li>Instagram → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Tap <strong>Sharing across profiles</strong> → select <strong>Instagram → Facebook</strong>.</li>
+<li>Enter <strong>Story</strong> → toggle <strong>Automatically share</strong> <strong>Off</strong>.</li>
+<li>Go back to <strong>Feed</strong> and <strong>Reels</strong> and toggle them <strong>Off</strong> too.</li>
+<li>Double-check under <strong>Advanced settings</strong> for any extra auto-share switches and disable them.</li>
 </ol>
 </details>
 <details>
-<summary>iOS app</summary>
+<summary>On iOS</summary>
 <ol>
-<li>Profile → <strong>≡</strong> → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
-<li><strong>Sharing across profiles</strong> → choose <strong>Instagram → Facebook</strong>.</li>
-<li><strong>Story</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
+<li>Instagram app → <strong>profile</strong> → <strong>Menu (≡)</strong> → <strong>Settings and privacy</strong>.</li>
+<li>Open <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong> → choose <strong>Instagram → Facebook</strong>.</li>
+<li>Set <strong>Automatically share</strong> to <strong>Off</strong> for <strong>Story</strong>, then repeat for <strong>Feed</strong> and <strong>Reels</strong>.</li>
+<li>If you previously enabled <strong>Share to Facebook</strong> from the post composer, toggle it off the next time you create content.</li>
 </ol>
 </details>
-</section>
-<section class="card" id="guide-stop-automatically-sharing-posts-to-facebook">
-<h3>Stop Automatically Sharing Posts to Facebook</h3>
-<details open>
-<summary>Web (browser)</summary>
-<ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li>Select <strong>Instagram → Facebook</strong>.</li>
-<li>Click <strong>Feed</strong> → turn <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>Android app</summary>
-<ol>
-<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li>Pick <strong>Instagram → Facebook</strong>.</li>
-<li>Tap <strong>Feed</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>iOS app</summary>
-<ol>
-<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li><strong>Instagram → Facebook</strong> → <strong>Feed</strong>.</li>
-<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
+<p><strong>Confirm turn off:</strong> Each Story, Feed, and Reels row should display <strong>Off</strong> with no blue toggle.</p>
+<p><strong>Related terms:</strong> cross-posting, auto-post, share to Facebook, automatic repost.</p>
 </section>
 <section class="card" id="guide-turn-off-cross-app-interactions-story-reactions-from-facebook">
 <h3>Turn Off Cross-App Interactions (Story Reactions from Facebook)</h3>
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Connected experiences</strong> → <strong>Interactions</strong> (or similar).</li>
 <li>Turn cross-app reactions/messages <strong>OFF</strong>.</li>
 </ol>
@@ -1589,7 +1648,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Click <strong>Hide story from</strong>.</li>
 <li>Search for people → click to select → <strong>Done</strong>/<strong>Save</strong>.</li>
 </ol>
@@ -1614,7 +1673,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels</strong> (or <strong>Reels and Remix</strong>).</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels</strong> (or <strong>Reels and Remix</strong>).</li>
 <li>Click <strong>Hide reels from</strong> → select accounts → <strong>Save</strong>.</li>
 </ol>
 </details>
@@ -1662,7 +1721,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
 <li>Turn on filtering.</li>
 <li>Click <strong>Manage custom words and phrases</strong> → add words/phrases → <strong>Save</strong>.</li>
 </ol>
@@ -1744,7 +1803,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
 <li>Under <strong>Other people</strong>, set to <strong>Don’t receive requests</strong>.</li>
 </ol>
 </details>
@@ -1768,7 +1827,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Messages</strong>.</li>
 <li>Find <strong>Who can add you to groups</strong> → choose <strong>People you follow</strong>.</li>
 </ol>
 </details>
@@ -1792,7 +1851,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Limits</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Limits</strong>.</li>
 <li>Click <strong>Continue</strong>.</li>
 <li>Choose who to limit (e.g., <strong>Accounts that don’t follow you</strong> or <strong>New followers</strong>).</li>
 <li>Set duration → <strong>Turn on</strong>.</li>
@@ -1840,39 +1899,12 @@
 </ol>
 </details>
 </section>
-<section class="card" id="guide-stop-automatically-sharing-reels-to-facebook">
-<h3>Stop Automatically Sharing Reels to Facebook</h3>
-<details open>
-<summary>Web (browser)</summary>
-<ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li>Choose <strong>Instagram → Facebook</strong>.</li>
-<li>Click <strong>Reels</strong> → <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>Android app</summary>
-<ol>
-<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li>Pick <strong>Instagram → Facebook</strong> → <strong>Reels</strong>.</li>
-<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>iOS app</summary>
-<ol>
-<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Sharing across profiles</strong>.</li>
-<li>Pick <strong>Instagram → Facebook</strong> → <strong>Reels</strong>.</li>
-<li>Toggle <strong>Automatically share</strong> <strong>OFF</strong>.</li>
-</ol>
-</details>
-</section>
 <section class="card" id="guide-allow-only-emoji-story-replies">
 <h3>Allow Only Emoji Story Replies</h3>
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Story</strong>.</li>
 <li>Under <strong>Allow message replies</strong>, choose <strong>Emoji reactions only</strong>.</li>
 </ol>
 </details>
@@ -1896,7 +1928,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Tags</strong>.</li>
 <li>Turn <strong>Manually approve tags</strong> <strong>ON</strong>.</li>
 <li>Review the <strong>Tagged posts</strong> queue and approve/deny.</li>
 </ol>
@@ -1923,7 +1955,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
 <li>Turn <strong>Allow remixing for photos</strong> <strong>OFF</strong>.</li>
 </ol>
 </details>
@@ -1947,7 +1979,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
 <li>Turn <strong>Allow remixing for videos</strong> <strong>OFF</strong>.</li>
 </ol>
 </details>
@@ -1971,7 +2003,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Reels and Remix</strong>.</li>
 <li>Turn <strong>Allow downloading</strong> <strong>OFF</strong>.</li>
 </ol>
 </details>
@@ -1995,7 +2027,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Your information and permissions</strong>.</li>
 <li>Click <strong>Off-Meta activity</strong> → <strong>Manage activity</strong> → <strong>Clear history</strong>.</li>
 <li>Turn <strong>Future Off-Meta activity</strong> <strong>OFF</strong>.</li>
@@ -2023,7 +2055,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Suggested content</strong> (or <strong>Account settings</strong>).</li>
+<li><strong>Settings and privacy</strong> → <strong>Suggested content</strong> (or <strong>Account settings</strong>).</li>
 <li>Click <strong>Sensitive content control</strong>.</li>
 <li>Choose <strong>Limit even more</strong> (or the strictest option).</li>
 </ol>
@@ -2072,7 +2104,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li><strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
+<li><strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Ad preferences</strong>.</li>
 <li>Click <strong>Ad settings</strong>.</li>
 <li>Turn <strong>Use activity from partners</strong> <strong>OFF</strong>.</li>
 <li>Turn <strong>Show ads based on activity on Meta products</strong> <strong>OFF</strong> (where available).</li>
@@ -2433,7 +2465,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
+<li>Profile → <strong>Settings and privacy</strong> → <strong>Privacy</strong> → <strong>Hidden words</strong>.</li>
 <li>Turn on <strong>Offensive words and phrases</strong>.</li>
 </ol>
 </details>
@@ -2671,7 +2703,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Apps and websites</strong>.</li>
 <li>Click <strong>Remove</strong> next to the app.</li>
 </ol>
@@ -2696,7 +2728,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Profile → <strong>Settings and privacy</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Click <strong>Download your information</strong>.</li>
 <li>Choose the format and click <strong>Request download</strong>.</li>
 </ol>
@@ -2852,7 +2884,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Click <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
 <li>Click <strong>Log out of all devices</strong>.</li>
 </ol>
@@ -2893,7 +2925,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Select <strong>Contacts syncing</strong>.</li>
 <li>Click <strong>Manage contacts</strong> → <strong>Delete all contacts</strong>.</li>
 </ol>
@@ -2918,7 +2950,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Open <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
+<li>Open <strong>Settings and privacy</strong> → <strong>Accounts Center</strong> → <strong>Your information and permissions</strong>.</li>
 <li>Choose <strong>Phone and SMS syncing</strong>.</li>
 <li>Turn the toggle <strong>Off</strong> and click <strong>Delete data</strong>.</li>
 </ol>
@@ -3168,7 +3200,7 @@
 <details open>
 <summary>Web (browser)</summary>
 <ol>
-<li>Profile → <strong>Settings &amp; privacy</strong> → <strong>Accounts Center</strong>.</li>
+<li>Profile → <strong>Settings and privacy</strong> → <strong>Accounts Center</strong>.</li>
 <li>Select <strong>Password and security</strong> → <strong>Where you’re logged in</strong>.</li>
 <li>Click a device → <strong>Log out</strong>.</li>
 </ol>


### PR DESCRIPTION
## Summary
- standardize Instagram guide references to the “Settings and privacy” menu wording
- add a dedicated reset-backup-codes action and document cancelling pending data download requests
- merge the Facebook auto-sharing actions into one card with a single settings path and confirmation checklist

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b0a5eba483238847e50c8f463361