### PR TITLE
Populate X platform guides

### DIFF
--- a/platform.html
+++ b/platform.html
@@ -40,6 +40,7 @@
       <a class="tile" href="./platforms/whatsapp.html" data-platform="whatsapp"><span>WhatsApp</span></a>
       <a class="tile" href="./platforms/telegram.html" data-platform="telegram"><span>Telegram</span></a>
     </section>
+    <p class="coming-soon" data-i18n="platforms.moreComing">More platforms are coming soon.</p>
   </main>
   <footer id="site-footer">
     <div class="wrapper footer-layout">

--- a/platforms/x.html
+++ b/platforms/x.html
@@ -1,361 +1,3453 @@
 <!DOCTYPE html>
-
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1" name="viewport"/>
-<meta content="#0b0f14" name="theme-color"/>
-<title>Social Risk Audit — X (Twitter)</title>
-<link href="../assets/css/styles.css" rel="stylesheet"/>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>X Privacy & Security Guides</title>
+  <link rel="stylesheet" href="../assets/css/main.css">
 </head>
-<body>
-<a class="skip" href="#main" data-i18n="site.skip">Skip to content</a>
-<div id="ui-overlay" aria-hidden="true"></div>
-<header>
-<div class="wrapper header-row">
-<a class="brand" href="../" data-i18n="site.brand">Social Risk Audit</a>
-<div class="menu-container">
-<button aria-controls="site-menu" aria-expanded="false" aria-label="Open menu" class="menu-toggle">☰</button>
-<nav aria-label="Primary" class="menu" hidden="" id="site-menu">
-<a href="../" data-i18n="nav.home">Home</a>
-<a href="../self-audit.html" data-i18n="nav.selfaudit">Self‑audit</a>
-<a href="../tools-methods.html">Tools and Methods</a>
-<a href="../platform.html" data-i18n="nav.platform">Platform</a>
-<a href="../why.html" data-i18n="nav.why">Why</a>
-<a href="../ethics.html" data-i18n="nav.ethics">Ethics</a>
-<a href="../about/" data-i18n="nav.about">About</a>
-<a href="../disclaimer/" data-i18n="nav.disclaimer">Disclaimer</a>
-</nav>
-</div>
-</div>
-</header>
-<main class="platform-page" id="main">
-<div class="wrapper platform-wrapper">
-<div aria-hidden="true" id="page-top"></div>
-<nav aria-label="Back navigation" class="crumbs">
-<a aria-label="Back to Platforms" class="crumb back" href="../platform.html">← Back</a>
-</nav>
-<nav aria-label="Breadcrumb" class="breadcrumb">
-<ol>
-<li><a href="../" data-i18n="nav.home">Home</a></li>
-<li><a href="../platform.html">Platforms</a></li>
-<li aria-current="page">X (Twitter)</li>
-</ol>
-</nav>
-<header class="platform-header">
-<h1>X (Twitter)</h1>
-<p class="lead">Practical privacy actions you can take today on X.</p>
-</header>
-<form action="" class="guide-search" id="guide-search-form" method="get" role="search">
-<label class="guide-search-label" for="guide-search-input">Search X privacy actions</label>
-<div class="guide-search-field">
-<input autocomplete="off" id="guide-search-input" name="q" placeholder="Search by action, keyword, or feature" type="search"/>
-<button class="guide-search-reset" type="reset">Clear</button>
-</div>
-</form>
-<p aria-live="polite" class="search-status" id="guide-search-count" role="status"></p>
-<p class="search-empty-message" hidden="" id="guide-search-empty">No actions matched your search. Try different keywords or remove filters.</p>
-<div class="platform-layout">
-<div class="platform-content" id="guide-content">
-<section class="card" id="navigation-primer">
-<h2>Navigation Primer</h2>
-<h3>Mobile (X app)</h3>
-<ul>
-<li>Tap your <strong>profile photo</strong> (top-left) to open the main menu.</li>
-<li>Select <strong>Settings and privacy</strong> from the menu for account and privacy controls.</li>
-<li>Inside Settings, use <strong>Search settings</strong> (top bar) to jump to specific features like “two-factor”.</li>
-<li>Privacy controls live under <strong>Privacy and safety</strong>; security controls are under <strong>Security and account access</strong>.</li>
-</ul>
-<h3>Desktop (twitter.com)</h3>
-<ul>
-<li>Go to <strong>twitter.com</strong> and sign in.</li>
-<li>Click <strong>More</strong> (left sidebar) → <strong>Settings and privacy</strong>.</li>
-<li>Use the left sidebar in Settings to switch between <strong>Your account</strong>, <strong>Privacy and safety</strong>, and <strong>Security and account access</strong>.</li>
-<li>The search field at the top of Settings helps you locate features quickly.</li>
-</ul>
-<p class="lead">If the menu changes wording, look for “Settings and privacy” and then the section that best matches the task (Security, Privacy, or Your account).</p>
-</section>
-<nav aria-label="Guides" class="card" id="guide-index">
-<h2>Guides</h2>
-<ol>
-<li class="guide-range-divider"><span>Guides #1–12</span></li>
-<li><a href="#guide-change-your-x-password">Change Your X Password</a></li>
-<li><a href="#guide-enable-x-two-factor-authentication">Enable X Two-Factor Authentication</a></li>
-<li><a href="#guide-generate-x-backup-codes">Generate X Backup Codes</a></li>
-<li><a href="#guide-review-x-active-sessions">Review X Active Sessions</a></li>
-<li><a href="#guide-update-x-account-information">Update X Account Information</a></li>
-<li><a href="#guide-protect-your-posts">Protect Your Posts (Private Account)</a></li>
-<li><a href="#guide-control-x-direct-messages">Control X Direct Messages</a></li>
-<li><a href="#guide-disable-x-discoverability">Disable Discoverability by Email or Phone</a></li>
-<li><a href="#guide-limit-x-ad-personalization">Limit X Ad Personalization</a></li>
-<li><a href="#guide-turn-off-x-location-tagging">Turn Off Location Tagging on X</a></li>
-<li><a href="#guide-remove-connected-apps-on-x">Remove Connected Apps on X</a></li>
-<li><a href="#guide-download-your-x-data">Download Your X Data Archive</a></li>
-</ol>
-</nav>
-<h2 class="guide-range-heading" id="range-1-12">Guides #1–12</h2>
-<section class="card" id="guide-change-your-x-password">
-<h2>Change Your X Password</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Go to <strong>twitter.com</strong> → <strong>More</strong> → <strong>Settings and privacy</strong>.</li>
-<li>Select <strong>Your account</strong> → <strong>Change your password</strong>.</li>
-<li>Enter your current password, then a strong new password twice, and click <strong>Save</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Your account</strong>.</li>
-<li>Tap <strong>Change your password</strong>.</li>
-<li>Enter your current password and create a new one, then tap <strong>Update password</strong>.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Use a unique password that isn’t shared with any other site.</p>
-</section>
-<section class="card" id="guide-enable-x-two-factor-authentication">
-<h2>Enable X Two-Factor Authentication</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Security and account access</strong> → <strong>Security</strong> → <strong>Two-factor authentication</strong>.</li>
-<li>Enable <strong>Authentication app</strong> or <strong>Security key</strong> (avoid SMS when possible).</li>
-<li>Follow the prompts to scan the QR code or register your key, then confirm.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Security and account access</strong> → <strong>Security</strong>.</li>
-<li>Tap <strong>Two-factor authentication</strong> and enable <strong>Authentication app</strong> or <strong>Security key</strong>.</li>
-<li>Complete the setup steps and confirm.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Pair an authenticator app with backup codes to avoid lockouts.</p>
-</section>
-<section class="card" id="guide-generate-x-backup-codes">
-<h2>Generate X Backup Codes</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Security and account access</strong> → <strong>Security</strong> → <strong>Two-factor authentication</strong>.</li>
-<li>Select <strong>Backup codes</strong> → <strong>Generate backup codes</strong>.</li>
-<li>Download or print the codes and store them securely offline.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Security and account access</strong> → <strong>Security</strong>.</li>
-<li>Tap <strong>Two-factor authentication</strong> → <strong>Backup codes</strong> → <strong>Generate</strong>.</li>
-<li>Copy the codes to a safe password manager or encrypted note.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Backup codes let you sign in if you lose your phone or hardware key.</p>
-</section>
-<section class="card" id="guide-review-x-active-sessions">
-<h2>Review X Active Sessions</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Security and account access</strong> → <strong>Apps and sessions</strong>.</li>
-<li>Click <strong>Sessions</strong>.</li>
-<li>Select <strong>Log out of all other sessions</strong>, then individually log out of anything unfamiliar.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Security and account access</strong> → <strong>Apps and sessions</strong>.</li>
-<li>Tap <strong>Sessions</strong>.</li>
-<li>Log out of devices you do not recognize.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Clearing old sessions stops former devices from regaining access.</p>
-</section>
-<section class="card" id="guide-update-x-account-information">
-<h2>Update X Account Information</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Your account</strong> → <strong>Account information</strong> (enter your password if prompted).</li>
-<li>Update your email and phone number, verify them, and ensure they’re private.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Your account</strong> → <strong>Account information</strong>.</li>
-<li>Review and update contact details, then confirm verification codes.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Use a secure email address that you check regularly and keep phone numbers up to date.</p>
-</section>
-<section class="card" id="guide-protect-your-posts">
-<h2>Protect Your Posts (Private Account)</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Privacy and safety</strong> → <strong>Audience and tagging</strong>.</li>
-<li>Toggle <strong>Protect your posts</strong> on, then confirm.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Privacy and safety</strong> → <strong>Audience and tagging</strong>.</li>
-<li>Enable <strong>Protect your posts</strong>.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> When protected, only approved followers see your posts and past content.</p>
-</section>
-<section class="card" id="guide-control-x-direct-messages">
-<h2>Control X Direct Messages</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Privacy and safety</strong> → <strong>Direct messages</strong>.</li>
-<li>Disable <strong>Allow message requests from everyone</strong>.</li>
-<li>Turn off <strong>Allow requests from verified users</strong> unless needed.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Privacy and safety</strong> → <strong>Direct messages</strong>.</li>
-<li>Adjust toggles to limit who can DM you and whether read receipts are sent.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Restricting DM requests blocks spam and phishing attempts.</p>
-</section>
-<section class="card" id="guide-disable-x-discoverability">
-<h2>Disable Discoverability by Email or Phone</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Privacy and safety</strong> → <strong>Discoverability and contacts</strong>.</li>
-<li>Uncheck <strong>Let people who have your email address find you on X</strong> and the phone option too.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Privacy and safety</strong> → <strong>Discoverability and contacts</strong>.</li>
-<li>Turn off both discoverability toggles.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Disabling discoverability keeps your account hidden from people uploading contact lists.</p>
-</section>
-<section class="card" id="guide-limit-x-ad-personalization">
-<h2>Limit X Ad Personalization</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Privacy and safety</strong> → <strong>Ads preferences</strong>.</li>
-<li>Toggle off <strong>Personalized ads</strong> and <strong>Inferred interests</strong>.</li>
-<li>Review the interest list and uncheck anything sensitive.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Privacy and safety</strong> → <strong>Ads preferences</strong>.</li>
-<li>Disable personalized ads and clear stored interests.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Turning off personalization reduces tracking and profiling for advertising.</p>
-</section>
-<section class="card" id="guide-turn-off-x-location-tagging">
-<h2>Turn Off Location Tagging on X</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Privacy and safety</strong> → <strong>Location information</strong>.</li>
-<li>Disable <strong>Add location information to your Posts</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Privacy and safety</strong> → <strong>Location information</strong>.</li>
-<li>Turn off adding location to posts and clear past location data if available.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Without location tags, posts reveal less about your real-world movements.</p>
-</section>
-<section class="card" id="guide-remove-connected-apps-on-x">
-<h2>Remove Connected Apps on X</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Security and account access</strong> → <strong>Apps and sessions</strong> → <strong>Connected apps</strong>.</li>
-<li>Click any app you no longer use → <strong>Revoke app permissions</strong>.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Security and account access</strong> → <strong>Apps and sessions</strong>.</li>
-<li>Tap <strong>Connected apps</strong> and revoke access for untrusted apps.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Removing unused apps stops them from reading your DMs or posting on your behalf.</p>
-</section>
-<section class="card" id="guide-download-your-x-data">
-<h2>Download Your X Data Archive</h2>
-<details open="">
-<summary>On Desktop</summary>
-<ol>
-<li>Settings → <strong>Your account</strong> → <strong>Download an archive of your data</strong>.</li>
-<li>Verify your password and email/phone, then request the archive.</li>
-<li>Check your email or notifications when the archive is ready to download.</li>
-</ol>
-</details>
-<details>
-<summary>On Mobile</summary>
-<ol>
-<li>Profile photo → <strong>Settings and privacy</strong> → <strong>Your account</strong> → <strong>Download an archive of your data</strong>.</li>
-<li>Authenticate, request the file, and wait for the notification to download.</li>
-</ol>
-</details>
-<p class="lead"><strong>Tips:</strong> Reviewing your archive shows what data X stores and highlights old content to remove.</p>
-</section>
-</div>
-<aside aria-label="On this page" class="platform-sidebar">
-<div class="card toc-card">
-<h2>On this page</h2>
-<nav aria-label="On this page">
-<ul>
-<li><a href="#navigation-primer">Navigation primer</a></li>
-<li><a href="#guide-index">Guide index</a></li>
-<li><a href="#range-1-12">Guides #1–12</a></li>
-</ul>
-</nav>
-</div>
-</aside>
-</div>
-<a class="back-to-top" href="#page-top">Back to top</a>
-</div>
-</main>
-<footer id="site-footer">
-<div class="wrapper footer-layout">
-<p>Utility-first build — no trackers.</p>
-<nav aria-label="Footer" class="footer-links">
-<a href="../" data-i18n="nav.home">Home</a>
-<a href="../self-audit.html" data-i18n="nav.selfaudit">Self‑audit</a>
-<a href="../tools-methods.html">Tools and Methods</a>
-<a href="../platform.html" data-i18n="nav.platform">Platform</a>
-<a href="../why.html" data-i18n="nav.why">Why</a>
-<a href="../ethics.html" data-i18n="nav.ethics">Ethics</a>
-<a href="../about/" data-i18n="nav.about">About</a>
-<a href="../disclaimer/" data-i18n="nav.disclaimer">Disclaimer</a>
-</nav>
-</div>
-</footer>
-<script defer="" src="../assets/js/i18n.js"></script>
-<script defer="" src="../assets/js/pledge-gate.js"></script>
-<script defer="" src="../assets/js/platform-guides.js"></script>
-<script defer="" src="../assets/js/main.js"></script>
+<body class="theme-dark">
+  <header class="site-header">
+    <a href="../index.html" class="logo">Social Risk Audit</a>
+    <nav class="site-nav">
+      <a href="../index.html">Home</a>
+      <a href="../self-audit.html">Self‑audit</a>
+      <a href="../platform.html" aria-current="page">Platform</a>
+      <a href="../about/index.html">About</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <h1 class="page-title">X — Privacy & Security</h1>
+
+    <section class="guide-filters">
+      <input id="guide-search" type="search" placeholder="Search guides" aria-label="Search guides">
+      <div class="guide-categories">
+        <button class="guide-filter" data-category="Account Security &amp; Login">Account Security &amp; Login</button>
+        <button class="guide-filter" data-category="Privacy &amp; Safety">Privacy &amp; Safety</button>
+        <button class="guide-filter" data-category="Tweets &amp; Replies">Tweets &amp; Replies</button>
+        <button class="guide-filter" data-category="Direct Messages">Direct Messages</button>
+        <button class="guide-filter" data-category="Media &amp; Sensitive Content">Media &amp; Sensitive Content</button>
+        <button class="guide-filter" data-category="Discovery &amp; Visibility">Discovery &amp; Visibility</button>
+        <button class="guide-filter" data-category="Ads &amp; Personalization">Ads &amp; Personalization</button>
+        <button class="guide-filter" data-category="Data &amp; Archive">Data &amp; Archive</button>
+        <button class="guide-filter" data-category="Spaces &amp; Audio">Spaces &amp; Audio</button>
+        <button class="guide-filter" data-category="Mute/Block/Reports">Mute/Block/Reports</button>
+        <button class="guide-filter" data-category="App Permissions">App Permissions</button>
+      </div>
+    </section>
+
+    <section id="guides" class="guide-grid">
+      <article id="change-account-password" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="password, login, credentials, security, change password">
+        <h3 class="guide-title">Change Your X Password</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Change your password</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Change your password.</li>
+            <li>Enter your current password, type a strong new password twice, and click Save.</li>
+            <li><em>Confirm:</em> Click Save to confirm the new password.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Change your password.</li>
+            <li>Enter your current password, type a strong new password twice, and tap Update password.</li>
+            <li><em>Confirm:</em> Tap Save to finish.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Change your password.</li>
+            <li>Enter your current password, type a strong new password twice, and tap Update password.</li>
+            <li><em>Confirm:</em> Tap Save to finish.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-authenticator-two-factor" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="2fa, two-factor, authenticator, security, login code">
+        <h3 class="guide-title">Enable Authenticator App Two-Factor</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Two-factor authentication</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Two-factor authentication.</li>
+            <li>Choose Authenticator app, scan the QR code, and enter the verification code.</li>
+            <li><em>Confirm:</em> Click Done to finish enabling two-factor authentication.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication.</li>
+            <li>Choose Authenticator app, scan the QR code, and enter the verification code.</li>
+            <li><em>Confirm:</em> Tap Done to finish.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication.</li>
+            <li>Choose Authenticator app, scan the QR code, and enter the verification code.</li>
+            <li><em>Confirm:</em> Tap Done to finish.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="add-security-key-two-factor" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="security key, hardware key, webauthn, 2fa, login">
+        <h3 class="guide-title">Add a Security Key for Two-Factor</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Two-factor authentication → Security key</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Two-factor authentication → Security key.</li>
+            <li>Select Security key, insert or tap your key, and follow the browser prompts to register it.</li>
+            <li><em>Confirm:</em> Click Done after the key is confirmed.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication → Security key.</li>
+            <li>Select Security key, insert or tap your key, and follow the prompts to register it.</li>
+            <li><em>Confirm:</em> Tap Done after the key is confirmed.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication → Security key.</li>
+            <li>Select Security key, insert or tap your key, and follow the prompts to register it.</li>
+            <li><em>Confirm:</em> Tap Done after the key is confirmed.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-sms-two-factor-backup" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="sms, text message, 2fa, backup, security">
+        <h3 class="guide-title">Enable SMS Two-Factor Backup</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Two-factor authentication</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Two-factor authentication.</li>
+            <li>Toggle Text message two-factor on and verify the phone number you want to use.</li>
+            <li><em>Confirm:</em> Enter the confirmation code and click Done.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication.</li>
+            <li>Toggle Text message two-factor on and verify the phone number you want to use.</li>
+            <li><em>Confirm:</em> Enter the confirmation code and tap Done.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication.</li>
+            <li>Toggle Text message two-factor on and verify the phone number you want to use.</li>
+            <li><em>Confirm:</em> Enter the confirmation code and tap Done.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="generate-backup-codes" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="backup codes, recovery, 2fa, login, security">
+        <h3 class="guide-title">Generate Backup Codes for Two-Factor</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Two-factor authentication → Backup codes</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Two-factor authentication → Backup codes.</li>
+            <li>Click Generate backup codes and download or copy the list to a secure location.</li>
+            <li><em>Confirm:</em> Click Done after storing the codes safely.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication → Backup codes.</li>
+            <li>Tap Generate backup codes and save the list to a secure location.</li>
+            <li><em>Confirm:</em> Tap Done after storing the codes safely.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Two-factor authentication → Backup codes.</li>
+            <li>Tap Generate backup codes and save the list to a secure location.</li>
+            <li><em>Confirm:</em> Tap Done after storing the codes safely.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-active-sessions" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="sessions, devices, logins, security, activity">
+        <h3 class="guide-title">Review Active Sessions</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Sessions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Sessions.</li>
+            <li>Review the list of active sessions and click Log out next to anything you do not recognize.</li>
+            <li><em>Confirm:</em> Click Log out to remove the session.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Review the list of active sessions and tap Log out next to anything you do not recognize.</li>
+            <li><em>Confirm:</em> Tap Log out to remove the session.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Review the list of active sessions and tap Log out next to anything you do not recognize.</li>
+            <li><em>Confirm:</em> Tap Log out to remove the session.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="log-out-other-sessions" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="log out, sessions, devices, security, sign out">
+        <h3 class="guide-title">Log Out of Other Sessions</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Log out of other sessions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Log out of other sessions.</li>
+            <li>Click Log out of other sessions to disconnect every device except the one you’re using.</li>
+            <li><em>Confirm:</em> Click Log out to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Log out of other sessions.</li>
+            <li>Tap Log out of other sessions to disconnect every device except the one you’re using.</li>
+            <li><em>Confirm:</em> Tap Log out to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Log out of other sessions.</li>
+            <li>Tap Log out of other sessions to disconnect every device except the one you’re using.</li>
+            <li><em>Confirm:</em> Tap Log out to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-login-verification-alerts" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="login alerts, notifications, security, email alert, sign-in">
+        <h3 class="guide-title">Turn On Login Verification Alerts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Login alerts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Login alerts.</li>
+            <li>Choose Email or Push notifications so you are alerted whenever your account is accessed.</li>
+            <li><em>Confirm:</em> Click Save to store your alert settings.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Login alerts.</li>
+            <li>Choose Email or Push notifications so you are alerted whenever your account is accessed.</li>
+            <li><em>Confirm:</em> Tap Save to store your alert settings.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Login alerts.</li>
+            <li>Choose Email or Push notifications so you are alerted whenever your account is accessed.</li>
+            <li><em>Confirm:</em> Tap Save to store your alert settings.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="update-account-email" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="email, account info, contact, login, security">
+        <h3 class="guide-title">Update Your Account Email Address</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Account information → Email</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Account information → Email.</li>
+            <li>Enter the new email address, complete the verification, and click Save.</li>
+            <li><em>Confirm:</em> Click Done after verifying the code sent to your new email.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Email.</li>
+            <li>Enter the new email address, complete the verification, and tap Save.</li>
+            <li><em>Confirm:</em> Tap Done after verifying the code sent to your new email.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Email.</li>
+            <li>Enter the new email address, complete the verification, and tap Save.</li>
+            <li><em>Confirm:</em> Tap Done after verifying the code sent to your new email.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="update-account-phone" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="phone, mobile, account info, security, contact">
+        <h3 class="guide-title">Update Your Account Phone Number</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Account information → Phone</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Account information → Phone.</li>
+            <li>Add or edit your phone number, verify the SMS code, and click Save.</li>
+            <li><em>Confirm:</em> Enter the code and click Done to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Phone.</li>
+            <li>Add or edit your phone number, verify the SMS code, and tap Save.</li>
+            <li><em>Confirm:</em> Enter the code and tap Done to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Phone.</li>
+            <li>Add or edit your phone number, verify the SMS code, and tap Save.</li>
+            <li><em>Confirm:</em> Enter the code and tap Done to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-password-reset-protection" class="guide-card" data-platform="x" data-category="Account Security &amp; Login" data-keywords="password reset, protection, security, email confirmation, safety">
+        <h3 class="guide-title">Enable Password Reset Protection</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Security → Additional password protection</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Security → Additional password protection.</li>
+            <li>Toggle Additional password protection on so resets require your email confirmation.</li>
+            <li><em>Confirm:</em> Click Save to lock in the setting.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Additional password protection.</li>
+            <li>Toggle Additional password protection on so resets require your email confirmation.</li>
+            <li><em>Confirm:</em> Tap Save to lock in the setting.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Security → Additional password protection.</li>
+            <li>Toggle Additional password protection on so resets require your email confirmation.</li>
+            <li><em>Confirm:</em> Tap Save to lock in the setting.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="protect-your-posts" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="private, protect tweets, followers, privacy, lock account">
+        <h3 class="guide-title">Protect Your Posts (Private Account)</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Audience and tagging → Protect your posts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Audience and tagging → Protect your posts.</li>
+            <li>Turn Protect your posts on so only approved followers can see what you share.</li>
+            <li><em>Confirm:</em> Click Save if prompted to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Protect your posts.</li>
+            <li>Turn Protect your posts on so only approved followers can see what you share.</li>
+            <li><em>Confirm:</em> Tap Save if prompted to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Protect your posts.</li>
+            <li>Turn Protect your posts on so only approved followers can see what you share.</li>
+            <li><em>Confirm:</em> Tap Save if prompted to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-follower-requests" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="follower requests, approve followers, privacy, pending, follow">
+        <h3 class="guide-title">Review Pending Follower Requests</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Audience and tagging → Follower requests</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Audience and tagging → Follower requests.</li>
+            <li>Open each pending request and click Confirm or Delete to control access.</li>
+            <li><em>Confirm:</em> Click Confirm or Delete to finalize your choice.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Follower requests.</li>
+            <li>Open each pending request and tap Confirm or Delete to control access.</li>
+            <li><em>Confirm:</em> Tap Confirm or Delete to finalize your choice.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Follower requests.</li>
+            <li>Open each pending request and tap Confirm or Delete to control access.</li>
+            <li><em>Confirm:</em> Tap Confirm or Delete to finalize your choice.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="limit-photo-tagging" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="photo tagging, tags, privacy, mentions, control">
+        <h3 class="guide-title">Limit Photo Tagging to People You Follow</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Audience and tagging → Photo tagging</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Set Who can tag you to Only people you follow so strangers cannot tag you in photos.</li>
+            <li><em>Confirm:</em> Click Save to store the tag limit.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Set Who can tag you to Only people you follow so strangers cannot tag you in photos.</li>
+            <li><em>Confirm:</em> Tap Save to store the tag limit.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Set Who can tag you to Only people you follow so strangers cannot tag you in photos.</li>
+            <li><em>Confirm:</em> Tap Save to store the tag limit.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-photo-tagging" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="photo tagging, privacy, tags, disable, safety">
+        <h3 class="guide-title">Turn Off Photo Tagging Entirely</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Audience and tagging → Photo tagging</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Switch Photo tagging to Off so nobody can tag you in images.</li>
+            <li><em>Confirm:</em> Click Save to lock the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Switch Photo tagging to Off so nobody can tag you in images.</li>
+            <li><em>Confirm:</em> Tap Save to lock the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Photo tagging.</li>
+            <li>Switch Photo tagging to Off so nobody can tag you in images.</li>
+            <li><em>Confirm:</em> Tap Save to lock the change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-safety-mode" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="safety mode, auto block, abuse, moderation, protection">
+        <h3 class="guide-title">Enable Safety Mode Auto-Block</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Safety → Safety mode</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Safety → Safety mode.</li>
+            <li>Turn Safety mode on and choose the duration you want auto-blocking to run.</li>
+            <li><em>Confirm:</em> Click Turn on to enable Safety mode.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Safety → Safety mode.</li>
+            <li>Turn Safety mode on and choose the duration you want auto-blocking to run.</li>
+            <li><em>Confirm:</em> Tap Turn on to enable Safety mode.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Safety → Safety mode.</li>
+            <li>Turn Safety mode on and choose the duration you want auto-blocking to run.</li>
+            <li><em>Confirm:</em> Tap Turn on to enable Safety mode.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-safety-mode-blocks" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="safety mode, auto block, review, unblock, safety">
+        <h3 class="guide-title">Review Safety Mode Auto-Blocks</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Safety → Safety mode → Review Safety mode</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Safety → Safety mode → Review Safety mode.</li>
+            <li>Open the list of accounts Safety mode blocked and click Undo on any you want to restore.</li>
+            <li><em>Confirm:</em> Click Undo to lift the auto-block.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Safety → Safety mode → Review Safety mode.</li>
+            <li>Open the list of accounts Safety mode blocked and tap Undo on any you want to restore.</li>
+            <li><em>Confirm:</em> Tap Undo to lift the auto-block.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Safety → Safety mode → Review Safety mode.</li>
+            <li>Open the list of accounts Safety mode blocked and tap Undo on any you want to restore.</li>
+            <li><em>Confirm:</em> Tap Undo to lift the auto-block.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-location-sharing" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="location, precise location, privacy, safety, gps">
+        <h3 class="guide-title">Disable Location Sharing on New Posts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Location information → Add location information to your Tweets</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Location information → Add location information to your Tweets.</li>
+            <li>Turn Add location information off so future posts do not include your precise location.</li>
+            <li><em>Confirm:</em> Click Save to apply the location change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Location information → Add location information to your Tweets.</li>
+            <li>Turn Add location information off so future posts do not include your precise location.</li>
+            <li><em>Confirm:</em> Tap Save to apply the location change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Location information → Add location information to your Tweets.</li>
+            <li>Turn Add location information off so future posts do not include your precise location.</li>
+            <li><em>Confirm:</em> Tap Save to apply the location change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-profile-location" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="profile, location, privacy, edit profile, city">
+        <h3 class="guide-title">Hide Your Profile Location</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Edit profile → Location</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Profile (left sidebar) to open your profile.</li>
+            <li>Click Edit profile → Location.</li>
+            <li>Clear the Location field or enter generic text, then click Save.</li>
+            <li><em>Confirm:</em> Click Save to update your profile.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) to open your profile.</li>
+            <li>Tap Edit profile → Location.</li>
+            <li>Clear the Location field or enter generic text, then tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to update your profile.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) to open your profile.</li>
+            <li>Tap Edit profile → Location.</li>
+            <li>Clear the Location field or enter generic text, then tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to update your profile.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-birthday" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="birthday, birth date, profile, privacy, visibility">
+        <h3 class="guide-title">Hide Your Birthday from Public View</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Edit profile → Birth date</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Profile (left sidebar) to open your profile.</li>
+            <li>Click Edit profile → Birth date.</li>
+            <li>Set each visibility control to Only you or remove the date entirely, then click Save.</li>
+            <li><em>Confirm:</em> Click Save to confirm the visibility change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) to open your profile.</li>
+            <li>Tap Edit profile → Birth date.</li>
+            <li>Set each visibility control to Only you or remove the date entirely, then tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to confirm the visibility change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) to open your profile.</li>
+            <li>Tap Edit profile → Birth date.</li>
+            <li>Set each visibility control to Only you or remove the date entirely, then tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to confirm the visibility change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="control-community-invites" class="guide-card" data-platform="x" data-category="Privacy &amp; Safety" data-keywords="communities, invites, privacy, control, membership">
+        <h3 class="guide-title">Control Who Can Invite You to Communities</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Communities → Community invitations</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Communities → Community invitations.</li>
+            <li>Choose Only people you follow or No one to limit who can invite you to a Community.</li>
+            <li><em>Confirm:</em> Click Save to store the invitation preference.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Communities → Community invitations.</li>
+            <li>Choose Only people you follow or No one to limit who can invite you to a Community.</li>
+            <li><em>Confirm:</em> Tap Save to store the invitation preference.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Communities → Community invitations.</li>
+            <li>Choose Only people you follow or No one to limit who can invite you to a Community.</li>
+            <li><em>Confirm:</em> Tap Save to store the invitation preference.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-discoverability-email" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="discoverability, email, search, privacy, contacts">
+        <h3 class="guide-title">Disable Discoverability by Email</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Discoverability and contacts → Let others find you by email</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Discoverability and contacts → Let others find you by email.</li>
+            <li>Turn off the email discoverability toggle so people cannot locate you with your address.</li>
+            <li><em>Confirm:</em> Click Save to apply the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Let others find you by email.</li>
+            <li>Turn off the email discoverability toggle so people cannot locate you with your address.</li>
+            <li><em>Confirm:</em> Tap Save to apply the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Let others find you by email.</li>
+            <li>Turn off the email discoverability toggle so people cannot locate you with your address.</li>
+            <li><em>Confirm:</em> Tap Save to apply the change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-discoverability-phone" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="discoverability, phone, search, privacy, contacts">
+        <h3 class="guide-title">Disable Discoverability by Phone</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Discoverability and contacts → Let others find you by phone</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Discoverability and contacts → Let others find you by phone.</li>
+            <li>Turn off the phone number discoverability toggle so people cannot search for you by number.</li>
+            <li><em>Confirm:</em> Click Save to apply the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Let others find you by phone.</li>
+            <li>Turn off the phone number discoverability toggle so people cannot search for you by number.</li>
+            <li><em>Confirm:</em> Tap Save to apply the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Let others find you by phone.</li>
+            <li>Turn off the phone number discoverability toggle so people cannot search for you by number.</li>
+            <li><em>Confirm:</em> Tap Save to apply the change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-address-book-matching" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="contacts, address book, sync, discoverability, privacy">
+        <h3 class="guide-title">Turn Off Address Book Matching</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Discoverability and contacts → Sync address book contacts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Discoverability and contacts → Sync address book contacts.</li>
+            <li>Switch off Sync address book contacts so X stops uploading your device contacts.</li>
+            <li><em>Confirm:</em> Click Save to keep contact syncing off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Sync address book contacts.</li>
+            <li>Switch off Sync address book contacts so X stops uploading your device contacts.</li>
+            <li><em>Confirm:</em> Tap Save to keep contact syncing off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Sync address book contacts.</li>
+            <li>Switch off Sync address book contacts so X stops uploading your device contacts.</li>
+            <li><em>Confirm:</em> Tap Save to keep contact syncing off.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="remove-synced-contacts" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="contacts, address book, delete, privacy, discoverability">
+        <h3 class="guide-title">Remove Synced Contacts from X</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Discoverability and contacts → Manage contacts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Discoverability and contacts → Manage contacts.</li>
+            <li>Click Remove all contacts to delete every imported entry from your account.</li>
+            <li><em>Confirm:</em> Click Remove to confirm contact deletion.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Manage contacts.</li>
+            <li>Tap Remove all contacts to delete every imported entry from your account.</li>
+            <li><em>Confirm:</em> Tap Remove to confirm contact deletion.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Discoverability and contacts → Manage contacts.</li>
+            <li>Tap Remove all contacts to delete every imported entry from your account.</li>
+            <li><em>Confirm:</em> Tap Remove to confirm contact deletion.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-personalized-trends" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="trends, explore, personalized, visibility, discover">
+        <h3 class="guide-title">Turn Off Personalized Trends</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Explore settings → Personalized trends</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Explore settings → Personalized trends.</li>
+            <li>Toggle Personalized trends off so Explore shows what’s happening without tailoring.</li>
+            <li><em>Confirm:</em> Click Save to keep personalized trends off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Explore settings → Personalized trends.</li>
+            <li>Toggle Personalized trends off so Explore shows what’s happening without tailoring.</li>
+            <li><em>Confirm:</em> Tap Save to keep personalized trends off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Explore settings → Personalized trends.</li>
+            <li>Toggle Personalized trends off so Explore shows what’s happening without tailoring.</li>
+            <li><em>Confirm:</em> Tap Save to keep personalized trends off.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="choose-custom-explore-location" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="explore, location, trends, visibility, custom location">
+        <h3 class="guide-title">Choose a Custom Explore Location</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Explore settings → Explore locations</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Explore settings → Explore locations.</li>
+            <li>Select a specific city or country so Explore ignores automatic location suggestions.</li>
+            <li><em>Confirm:</em> Click Done to set the Explore location.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Explore settings → Explore locations.</li>
+            <li>Select a specific city or country so Explore ignores automatic location suggestions.</li>
+            <li><em>Confirm:</em> Tap Done to set the Explore location.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Explore settings → Explore locations.</li>
+            <li>Select a specific city or country so Explore ignores automatic location suggestions.</li>
+            <li><em>Confirm:</em> Tap Done to set the Explore location.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="switch-to-latest-tweets" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="timeline, latest, chronological, home, feed">
+        <h3 class="guide-title">Switch Home Timeline to Latest Tweets</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Home timeline → Content preferences</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Home timeline → Content preferences.</li>
+            <li>Choose See latest Tweets instead so your Home timeline stops ranking posts algorithmically.</li>
+            <li><em>Confirm:</em> Click Switch to latest to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Home timeline → Content preferences.</li>
+            <li>Choose See latest Tweets instead so your Home timeline stops ranking posts algorithmically.</li>
+            <li><em>Confirm:</em> Tap Switch to latest to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Home timeline → Content preferences.</li>
+            <li>Choose See latest Tweets instead so your Home timeline stops ranking posts algorithmically.</li>
+            <li><em>Confirm:</em> Tap Switch to latest to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="remove-selected-interests" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="interests, topics, recommendations, personalization, explore">
+        <h3 class="guide-title">Remove Selected Interests from Recommendations</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Topics → Following</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Topics → Following.</li>
+            <li>Uncheck or remove topics you no longer want influencing your recommendations.</li>
+            <li><em>Confirm:</em> Click Done after adjusting your topics.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Topics → Following.</li>
+            <li>Uncheck or remove topics you no longer want influencing your recommendations.</li>
+            <li><em>Confirm:</em> Tap Done after adjusting your topics.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Topics → Following.</li>
+            <li>Uncheck or remove topics you no longer want influencing your recommendations.</li>
+            <li><em>Confirm:</em> Tap Done after adjusting your topics.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="clear-search-history-suggestions" class="guide-card" data-platform="x" data-category="Discovery &amp; Visibility" data-keywords="search, history, clear, privacy, suggestions">
+        <h3 class="guide-title">Clear Search History Suggestions</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Search settings → Search history</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Search settings → Search history.</li>
+            <li>Click Clear all to remove stored search queries from suggestions.</li>
+            <li><em>Confirm:</em> Click Clear to confirm search history deletion.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Search settings → Search history.</li>
+            <li>Tap Clear all to remove stored search queries from suggestions.</li>
+            <li><em>Confirm:</em> Tap Clear to confirm search history deletion.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Search settings → Search history.</li>
+            <li>Tap Clear all to remove stored search queries from suggestions.</li>
+            <li><em>Confirm:</em> Tap Clear to confirm search history deletion.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="set-default-reply-controls" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="replies, control, followers, privacy, reply settings">
+        <h3 class="guide-title">Set Default Reply Controls to Followers Only</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Audience and tagging → Replies</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Audience and tagging → Replies.</li>
+            <li>Set Who can reply to People you follow so new posts limit responses to your followers.</li>
+            <li><em>Confirm:</em> Click Save to update your default reply controls.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Replies.</li>
+            <li>Set Who can reply to People you follow so new posts limit responses to your followers.</li>
+            <li><em>Confirm:</em> Tap Save to update your default reply controls.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Audience and tagging → Replies.</li>
+            <li>Set Who can reply to People you follow so new posts limit responses to your followers.</li>
+            <li><em>Confirm:</em> Tap Save to update your default reply controls.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="update-reply-controls-posted-tweet" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="reply control, tweets, privacy, followers, limit replies">
+        <h3 class="guide-title">Update Reply Controls on a Posted Tweet</h3>
+        <p class="settings-path"><strong>Path:</strong> Tweet → More options → Change who can reply</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the tweet you want to change.</li>
+            <li>Click the ••• More icon and choose Change who can reply.</li>
+            <li>Pick Only people you follow or Only people you mention.</li>
+            <li><em>Confirm:</em> Click Update to apply the reply limit.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the tweet you want to change.</li>
+            <li>Tap the ••• icon and choose Change who can reply.</li>
+            <li>Pick Only people you follow or Only people you mention.</li>
+            <li><em>Confirm:</em> Tap Update to apply the reply limit.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the tweet you want to change.</li>
+            <li>Tap the ••• icon and choose Change who can reply.</li>
+            <li>Pick Only people you follow or Only people you mention.</li>
+            <li><em>Confirm:</em> Tap Update to apply the reply limit.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="share-tweet-with-circle" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="twitter circle, audience, tweet, privacy, sharing">
+        <h3 class="guide-title">Share a Tweet with Your Twitter Circle</h3>
+        <p class="settings-path"><strong>Path:</strong> Composer → Audience picker → Twitter Circle</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Tweet to open the composer.</li>
+            <li>Select the Everyone audience button and choose Twitter Circle.</li>
+            <li>Compose your post and make sure the circle badge appears.</li>
+            <li><em>Confirm:</em> Click Tweet to share only with your circle.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap the Compose button.</li>
+            <li>Tap the audience selector and choose Twitter Circle.</li>
+            <li>Write your tweet and confirm the circle badge shows.</li>
+            <li><em>Confirm:</em> Tap Tweet to share only with your circle.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap the Compose button.</li>
+            <li>Tap the audience selector and choose Twitter Circle.</li>
+            <li>Write your tweet and confirm the circle badge shows.</li>
+            <li><em>Confirm:</em> Tap Tweet to share only with your circle.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-a-reply" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="hide reply, moderation, tweets, privacy, control">
+        <h3 class="guide-title">Hide a Reply to Your Tweet</h3>
+        <p class="settings-path"><strong>Path:</strong> Tweet → Reply → Hide reply</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open your tweet and scroll to the reply you want to hide.</li>
+            <li>Click the ••• icon on that reply and choose Hide reply.</li>
+            <li>Review the confirmation message explaining what happens.</li>
+            <li><em>Confirm:</em> Click Hide to move the reply to the hidden tab.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open your tweet and find the reply you want to hide.</li>
+            <li>Tap the ••• icon on that reply and choose Hide reply.</li>
+            <li>Review the confirmation message explaining what happens.</li>
+            <li><em>Confirm:</em> Tap Hide to move the reply to the hidden tab.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open your tweet and find the reply you want to hide.</li>
+            <li>Tap the ••• icon on that reply and choose Hide reply.</li>
+            <li>Review the confirmation message explaining what happens.</li>
+            <li><em>Confirm:</em> Tap Hide to move the reply to the hidden tab.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="unhide-a-reply" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="unhide reply, moderation, tweets, control, visibility">
+        <h3 class="guide-title">Unhide a Hidden Reply</h3>
+        <p class="settings-path"><strong>Path:</strong> Tweet → Hidden replies → Unhide</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open your tweet and tap Hidden replies.</li>
+            <li>Review the list of hidden responses.</li>
+            <li>Click the reply’s ••• icon and choose Unhide reply.</li>
+            <li><em>Confirm:</em> Click Unhide to return the reply to the main thread.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open your tweet and tap Hidden replies.</li>
+            <li>Review the list of hidden responses.</li>
+            <li>Tap the reply’s ••• icon and choose Unhide reply.</li>
+            <li><em>Confirm:</em> Tap Unhide to return the reply to the main thread.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open your tweet and tap Hidden replies.</li>
+            <li>Review the list of hidden responses.</li>
+            <li>Tap the reply’s ••• icon and choose Unhide reply.</li>
+            <li><em>Confirm:</em> Tap Unhide to return the reply to the main thread.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="delete-a-tweet" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="delete, tweet, remove, content, cleanup">
+        <h3 class="guide-title">Delete a Tweet</h3>
+        <p class="settings-path"><strong>Path:</strong> Tweet → More options → Delete</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the tweet you want to remove.</li>
+            <li>Click the ••• icon and choose Delete.</li>
+            <li>Review the reminder that deletion is permanent.</li>
+            <li><em>Confirm:</em> Click Delete to remove the tweet.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the tweet you want to remove.</li>
+            <li>Tap the ••• icon and choose Delete.</li>
+            <li>Review the reminder that deletion is permanent.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the tweet.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the tweet you want to remove.</li>
+            <li>Tap the ••• icon and choose Delete.</li>
+            <li>Review the reminder that deletion is permanent.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the tweet.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="delete-a-scheduled-tweet" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="scheduled tweet, draft, delete, unsent, cleanup">
+        <h3 class="guide-title">Delete a Scheduled Tweet</h3>
+        <p class="settings-path"><strong>Path:</strong> Composer → Unsent Tweets → Scheduled → Delete</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Tweet to open the composer, then click Unsent Tweets.</li>
+            <li>Switch to the Scheduled tab.</li>
+            <li>Select the scheduled tweet you want to remove.</li>
+            <li><em>Confirm:</em> Click Delete to cancel the scheduled post.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap Compose, then tap Unsent Tweets.</li>
+            <li>Switch to the Scheduled tab.</li>
+            <li>Select the scheduled tweet you want to remove.</li>
+            <li><em>Confirm:</em> Tap Delete to cancel the scheduled post.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap Compose, then tap Unsent Tweets.</li>
+            <li>Switch to the Scheduled tab.</li>
+            <li>Select the scheduled tweet you want to remove.</li>
+            <li><em>Confirm:</em> Tap Delete to cancel the scheduled post.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="unpin-a-tweet" class="guide-card" data-platform="x" data-category="Tweets &amp; Replies" data-keywords="unpin, pin, profile, tweet, visibility">
+        <h3 class="guide-title">Unpin a Tweet from Your Profile</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile → Pinned tweet → Unpin</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open your profile and scroll to the pinned tweet.</li>
+            <li>Click the ••• icon on the pinned post and choose Unpin from profile.</li>
+            <li>Read the prompt explaining the change.</li>
+            <li><em>Confirm:</em> Click Unpin to remove it from the top of your profile.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open your profile and locate the pinned tweet.</li>
+            <li>Tap the ••• icon on the pinned post and choose Unpin from profile.</li>
+            <li>Read the prompt explaining the change.</li>
+            <li><em>Confirm:</em> Tap Unpin to remove it from the top of your profile.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open your profile and locate the pinned tweet.</li>
+            <li>Tap the ••• icon on the pinned post and choose Unpin from profile.</li>
+            <li>Read the prompt explaining the change.</li>
+            <li><em>Confirm:</em> Tap Unpin to remove it from the top of your profile.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="control-who-can-message" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, message requests, privacy, followers, inbox">
+        <h3 class="guide-title">Control Who Can Message You</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Direct Messages → Allow message requests from</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Direct Messages → Allow message requests from.</li>
+            <li>Choose People you follow to block unsolicited DMs from strangers.</li>
+            <li><em>Confirm:</em> Click Save to lock your message audience.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Allow message requests from.</li>
+            <li>Choose People you follow to block unsolicited DMs from strangers.</li>
+            <li><em>Confirm:</em> Tap Save to lock your message audience.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Allow message requests from.</li>
+            <li>Choose People you follow to block unsolicited DMs from strangers.</li>
+            <li><em>Confirm:</em> Tap Save to lock your message audience.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-dm-quality-filter" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, quality filter, spam, requests, inbox">
+        <h3 class="guide-title">Turn On Quality Filter for Message Requests</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Direct Messages → Filter low-quality messages</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Direct Messages → Filter low-quality messages.</li>
+            <li>Turn on the Quality filter so suspected spam is hidden from your main inbox.</li>
+            <li><em>Confirm:</em> Click Save to keep the filter active.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Filter low-quality messages.</li>
+            <li>Turn on the Quality filter so suspected spam is hidden from your main inbox.</li>
+            <li><em>Confirm:</em> Tap Save to keep the filter active.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Filter low-quality messages.</li>
+            <li>Turn on the Quality filter so suspected spam is hidden from your main inbox.</li>
+            <li><em>Confirm:</em> Tap Save to keep the filter active.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-read-receipts" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, read receipts, privacy, seen, messages">
+        <h3 class="guide-title">Turn Off Read Receipts in DMs</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Direct Messages → Show read receipts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Direct Messages → Show read receipts.</li>
+            <li>Switch Show read receipts off so others can’t see when you’ve read messages.</li>
+            <li><em>Confirm:</em> Click Save to confirm the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Show read receipts.</li>
+            <li>Switch Show read receipts off so others can’t see when you’ve read messages.</li>
+            <li><em>Confirm:</em> Tap Save to confirm the change.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Show read receipts.</li>
+            <li>Switch Show read receipts off so others can’t see when you’ve read messages.</li>
+            <li><em>Confirm:</em> Tap Save to confirm the change.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="approve-message-request" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="message request, approve, decline, dm, inbox">
+        <h3 class="guide-title">Approve or Decline a Message Request</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Requests → Approve or Delete</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Messages and open the Requests tab.</li>
+            <li>Select the request you want to review.</li>
+            <li>Read the preview and choose Accept or Delete.</li>
+            <li><em>Confirm:</em> Click Accept to allow future messages or Delete to decline.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap Messages and open the Requests tab.</li>
+            <li>Select the request you want to review.</li>
+            <li>Read the preview and choose Accept or Delete.</li>
+            <li><em>Confirm:</em> Tap Accept to allow future messages or Delete to decline.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap Messages and open the Requests tab.</li>
+            <li>Select the request you want to review.</li>
+            <li>Read the preview and choose Accept or Delete.</li>
+            <li><em>Confirm:</em> Tap Accept to allow future messages or Delete to decline.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="delete-dm-conversation" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, conversation, delete, messages, cleanup">
+        <h3 class="guide-title">Delete a DM Conversation</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Conversation → Delete</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click Messages and open the conversation you want to remove.</li>
+            <li>Click the i info icon, then choose Delete conversation.</li>
+            <li>Review the reminder that deletion only affects your view.</li>
+            <li><em>Confirm:</em> Click Delete to remove the thread from your inbox.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap Messages and open the conversation you want to remove.</li>
+            <li>Tap the info icon, then choose Delete conversation.</li>
+            <li>Review the reminder that deletion only affects your view.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the thread from your inbox.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap Messages and open the conversation you want to remove.</li>
+            <li>Tap the info icon, then choose Delete conversation.</li>
+            <li>Review the reminder that deletion only affects your view.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the thread from your inbox.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="delete-individual-dm" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, delete message, privacy, cleanup, conversation">
+        <h3 class="guide-title">Delete an Individual DM</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Conversation → Delete message</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the DM conversation that has the message you want to remove.</li>
+            <li>Hover over the message, click the ••• icon, and choose Delete message.</li>
+            <li>Confirm you only want to delete it for yourself.</li>
+            <li><em>Confirm:</em> Click Delete to remove the message from your view.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the DM conversation that has the message you want to remove.</li>
+            <li>Tap and hold the message, then choose Delete message.</li>
+            <li>Confirm you only want to delete it for yourself.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the message from your view.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the DM conversation that has the message you want to remove.</li>
+            <li>Tap and hold the message, then choose Delete message.</li>
+            <li>Confirm you only want to delete it for yourself.</li>
+            <li><em>Confirm:</em> Tap Delete to remove the message from your view.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="report-dm-for-spam" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, spam, report, abuse, safety">
+        <h3 class="guide-title">Report a DM for Spam</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Conversation → Report</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the DM conversation with the suspicious message.</li>
+            <li>Click the info icon and choose Report conversation.</li>
+            <li>Select Spam or unwanted content as the reason.</li>
+            <li><em>Confirm:</em> Click Report to submit the abuse report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the DM conversation with the suspicious message.</li>
+            <li>Tap the info icon and choose Report conversation.</li>
+            <li>Select Spam or unwanted content as the reason.</li>
+            <li><em>Confirm:</em> Tap Report to submit the abuse report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the DM conversation with the suspicious message.</li>
+            <li>Tap the info icon and choose Report conversation.</li>
+            <li>Select Spam or unwanted content as the reason.</li>
+            <li><em>Confirm:</em> Tap Report to submit the abuse report.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="leave-a-group-dm" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="group dm, leave, conversation, privacy, messages">
+        <h3 class="guide-title">Leave a Group DM</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Group conversation → Leave</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the group DM you want to leave.</li>
+            <li>Click the info icon and choose Leave conversation.</li>
+            <li>Review the warning that you will no longer receive messages.</li>
+            <li><em>Confirm:</em> Click Leave to exit the group.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the group DM you want to leave.</li>
+            <li>Tap the info icon and choose Leave conversation.</li>
+            <li>Review the warning that you will no longer receive messages.</li>
+            <li><em>Confirm:</em> Tap Leave to exit the group.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the group DM you want to leave.</li>
+            <li>Tap the info icon and choose Leave conversation.</li>
+            <li>Review the warning that you will no longer receive messages.</li>
+            <li><em>Confirm:</em> Tap Leave to exit the group.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="mute-dm-conversation" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="dm, mute, notifications, conversation, silence">
+        <h3 class="guide-title">Mute a DM Conversation</h3>
+        <p class="settings-path"><strong>Path:</strong> Messages → Conversation → Notifications</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the DM conversation you want to mute.</li>
+            <li>Click the bell icon (Mute) in the conversation header.</li>
+            <li>Choose whether to mute for 1 hour, 8 hours, or indefinitely.</li>
+            <li><em>Confirm:</em> Click Mute to silence notifications.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the DM conversation you want to mute.</li>
+            <li>Tap the bell icon or info menu and select Mute notifications.</li>
+            <li>Choose whether to mute for 1 hour, 8 hours, or indefinitely.</li>
+            <li><em>Confirm:</em> Tap Mute to silence notifications.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the DM conversation you want to mute.</li>
+            <li>Tap the bell icon or info menu and select Mute notifications.</li>
+            <li>Choose whether to mute for 1 hour, 8 hours, or indefinitely.</li>
+            <li><em>Confirm:</em> Tap Mute to silence notifications.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-group-dm-invites" class="guide-card" data-platform="x" data-category="Direct Messages" data-keywords="group dm, invites, privacy, messages, control">
+        <h3 class="guide-title">Turn Off Group DM Invites from Anyone</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Direct Messages → Allow group chat invitations</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Direct Messages → Allow group chat invitations.</li>
+            <li>Turn the group chat invitations toggle off so only people you follow can add you.</li>
+            <li><em>Confirm:</em> Click Save to keep invitations limited.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Allow group chat invitations.</li>
+            <li>Turn the group chat invitations toggle off so only people you follow can add you.</li>
+            <li><em>Confirm:</em> Tap Save to keep invitations limited.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Direct Messages → Allow group chat invitations.</li>
+            <li>Turn the group chat invitations toggle off so only people you follow can add you.</li>
+            <li><em>Confirm:</em> Tap Save to keep invitations limited.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-sensitive-content-search" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="sensitive content, search, filter, safety, media">
+        <h3 class="guide-title">Hide Sensitive Content in Search</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Search settings → Hide sensitive content</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Search settings → Hide sensitive content.</li>
+            <li>Turn on Hide sensitive content so search results filter potentially graphic media.</li>
+            <li><em>Confirm:</em> Click Save to apply the search filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Search settings → Hide sensitive content.</li>
+            <li>Turn on Hide sensitive content so search results filter potentially graphic media.</li>
+            <li><em>Confirm:</em> Tap Save to apply the search filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Search settings → Hide sensitive content.</li>
+            <li>Turn on Hide sensitive content so search results filter potentially graphic media.</li>
+            <li><em>Confirm:</em> Tap Save to apply the search filter.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-display-sensitive-media" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="sensitive media, display, filter, privacy, timeline">
+        <h3 class="guide-title">Disable Display of Sensitive Media</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Display media that may contain sensitive content</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Display media that may contain sensitive content.</li>
+            <li>Turn the display toggle off so sensitive images and videos stay hidden by default.</li>
+            <li><em>Confirm:</em> Click Save to keep sensitive media hidden.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Display media that may contain sensitive content.</li>
+            <li>Turn the display toggle off so sensitive images and videos stay hidden by default.</li>
+            <li><em>Confirm:</em> Tap Save to keep sensitive media hidden.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Display media that may contain sensitive content.</li>
+            <li>Turn the display toggle off so sensitive images and videos stay hidden by default.</li>
+            <li><em>Confirm:</em> Tap Save to keep sensitive media hidden.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="mark-media-as-sensitive" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="mark sensitive, media, privacy, warning, content">
+        <h3 class="guide-title">Mark Media You Tweet as Sensitive</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Content you see → Mark media you Tweet as containing material that may be sensitive</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Content you see → Mark media you Tweet as containing material that may be sensitive.</li>
+            <li>Turn this toggle on so your uploads carry a sensitive content warning.</li>
+            <li><em>Confirm:</em> Click Save to keep the warning enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Mark media you Tweet as containing material that may be sensitive.</li>
+            <li>Turn this toggle on so your uploads carry a sensitive content warning.</li>
+            <li><em>Confirm:</em> Tap Save to keep the warning enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Content you see → Mark media you Tweet as containing material that may be sensitive.</li>
+            <li>Turn this toggle on so your uploads carry a sensitive content warning.</li>
+            <li><em>Confirm:</em> Tap Save to keep the warning enabled.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-video-autoplay" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="autoplay, video, data, media, timeline">
+        <h3 class="guide-title">Disable Video Autoplay</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Data usage → Autoplay</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Never so videos play only when you press them.</li>
+            <li><em>Confirm:</em> Click Save to disable autoplay.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Never so videos play only when you press them.</li>
+            <li><em>Confirm:</em> Tap Save to disable autoplay.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Never so videos play only when you press them.</li>
+            <li><em>Confirm:</em> Tap Save to disable autoplay.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="autoplay-wifi-only" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="autoplay, wifi, data, videos, media">
+        <h3 class="guide-title">Restrict Autoplay to Wi-Fi Only</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Data usage → Autoplay</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Wi-Fi only so mobile data connections never auto-play videos.</li>
+            <li><em>Confirm:</em> Click Save to keep autoplay restricted to Wi-Fi.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Wi-Fi only so mobile data connections never auto-play videos.</li>
+            <li><em>Confirm:</em> Tap Save to keep autoplay restricted to Wi-Fi.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Autoplay.</li>
+            <li>Set Autoplay to Wi-Fi only so mobile data connections never auto-play videos.</li>
+            <li><em>Confirm:</em> Tap Save to keep autoplay restricted to Wi-Fi.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-data-saver" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="data saver, media, bandwidth, compression, usage">
+        <h3 class="guide-title">Enable Data Saver for Media</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Data usage → Data saver</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Data usage → Data saver.</li>
+            <li>Turn Data saver on so videos play at lower quality and images load in standard definition.</li>
+            <li><em>Confirm:</em> Click Save to activate Data saver.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Data saver.</li>
+            <li>Turn Data saver on so videos play at lower quality and images load in standard definition.</li>
+            <li><em>Confirm:</em> Tap Save to activate Data saver.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → Data saver.</li>
+            <li>Turn Data saver on so videos play at lower quality and images load in standard definition.</li>
+            <li><em>Confirm:</em> Tap Save to activate Data saver.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-high-quality-video" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="video upload, high quality, data, media, bandwidth">
+        <h3 class="guide-title">Disable High Quality Video Uploads</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Data usage → High-quality video</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Data usage → High-quality video.</li>
+            <li>Turn off high-quality video uploads so clips always upload in standard definition.</li>
+            <li><em>Confirm:</em> Click Save to cap video upload quality.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → High-quality video.</li>
+            <li>Turn off high-quality video uploads so clips always upload in standard definition.</li>
+            <li><em>Confirm:</em> Tap Save to cap video upload quality.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → High-quality video.</li>
+            <li>Turn off high-quality video uploads so clips always upload in standard definition.</li>
+            <li><em>Confirm:</em> Tap Save to cap video upload quality.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-high-quality-images" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="image upload, high quality, data, media, bandwidth">
+        <h3 class="guide-title">Disable High Quality Image Uploads</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Data usage → High-quality image uploads</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Data usage → High-quality image uploads.</li>
+            <li>Set image uploads to Never so photos send in standard quality unless you override them.</li>
+            <li><em>Confirm:</em> Click Save to cap image upload quality.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → High-quality image uploads.</li>
+            <li>Set image uploads to Never so photos send in standard quality unless you override them.</li>
+            <li><em>Confirm:</em> Tap Save to cap image upload quality.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Data usage → High-quality image uploads.</li>
+            <li>Set image uploads to Never so photos send in standard quality unless you override them.</li>
+            <li><em>Confirm:</em> Tap Save to cap image upload quality.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-alt-text-reminders" class="guide-card" data-platform="x" data-category="Media &amp; Sensitive Content" data-keywords="alt text, accessibility, images, reminder, media">
+        <h3 class="guide-title">Enable Alt Text Reminders for Images</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Accessibility, display, and languages → Accessibility → Receive image description reminder</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Accessibility, display, and languages → Accessibility → Receive image description reminder.</li>
+            <li>Turn on image description reminders so the composer nudges you to add alt text.</li>
+            <li><em>Confirm:</em> Click Save to keep reminders enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Accessibility → Receive image description reminder.</li>
+            <li>Turn on image description reminders so the composer nudges you to add alt text.</li>
+            <li><em>Confirm:</em> Tap Save to keep reminders enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Accessibility, display, and languages → Accessibility → Receive image description reminder.</li>
+            <li>Turn on image description reminders so the composer nudges you to add alt text.</li>
+            <li><em>Confirm:</em> Tap Save to keep reminders enabled.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-personalized-ads" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, personalized, privacy, targeting, advertising">
+        <h3 class="guide-title">Disable Personalized Ads</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Personalized ads</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Personalized ads.</li>
+            <li>Turn off Personalized ads so campaigns use only generic targeting.</li>
+            <li><em>Confirm:</em> Click Save to opt out of personalized ads.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Personalized ads.</li>
+            <li>Turn off Personalized ads so campaigns use only generic targeting.</li>
+            <li><em>Confirm:</em> Tap Save to opt out of personalized ads.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Personalized ads.</li>
+            <li>Turn off Personalized ads so campaigns use only generic targeting.</li>
+            <li><em>Confirm:</em> Tap Save to opt out of personalized ads.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-interest-based-ads" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, interests, targeting, privacy, advertising">
+        <h3 class="guide-title">Disable Interest-Based Ads</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Interests</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Interests.</li>
+            <li>Uncheck every interest or click Deselect all so ads stop using your interests.</li>
+            <li><em>Confirm:</em> Click Save to clear your ad interests.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Interests.</li>
+            <li>Uncheck every interest or tap Deselect all so ads stop using your interests.</li>
+            <li><em>Confirm:</em> Tap Save to clear your ad interests.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Interests.</li>
+            <li>Uncheck every interest or tap Deselect all so ads stop using your interests.</li>
+            <li><em>Confirm:</em> Tap Save to clear your ad interests.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-ad-partner-data" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, partners, data sharing, privacy, advertising">
+        <h3 class="guide-title">Disable Ad Data from Partners</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Data shared with business partners</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Data shared with business partners.</li>
+            <li>Turn this setting off so X doesn’t use partner data to personalize ads.</li>
+            <li><em>Confirm:</em> Click Save to stop partner-based personalization.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Data shared with business partners.</li>
+            <li>Turn this setting off so X doesn’t use partner data to personalize ads.</li>
+            <li><em>Confirm:</em> Tap Save to stop partner-based personalization.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Data shared with business partners.</li>
+            <li>Turn this setting off so X doesn’t use partner data to personalize ads.</li>
+            <li><em>Confirm:</em> Tap Save to stop partner-based personalization.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="reset-advertiser-interests" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, interests, reset, advertiser, preferences">
+        <h3 class="guide-title">Reset Your Advertiser Interests</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Your advertiser list</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Your advertiser list.</li>
+            <li>Click Clear all to remove advertisers who added you to tailored audiences.</li>
+            <li><em>Confirm:</em> Click Clear to reset the advertiser list.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Your advertiser list.</li>
+            <li>Tap Clear all to remove advertisers who added you to tailored audiences.</li>
+            <li><em>Confirm:</em> Tap Clear to reset the advertiser list.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Your advertiser list.</li>
+            <li>Tap Clear all to remove advertisers who added you to tailored audiences.</li>
+            <li><em>Confirm:</em> Tap Clear to reset the advertiser list.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="opt-out-tailored-audiences" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, tailored audience, opt out, privacy, advertising">
+        <h3 class="guide-title">Opt Out of Tailored Audiences</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Tailored audiences</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Tailored audiences.</li>
+            <li>Turn the tailored audiences toggle off so advertisers can’t add you to custom lists.</li>
+            <li><em>Confirm:</em> Click Save to opt out of tailored audiences.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Tailored audiences.</li>
+            <li>Turn the tailored audiences toggle off so advertisers can’t add you to custom lists.</li>
+            <li><em>Confirm:</em> Tap Save to opt out of tailored audiences.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Tailored audiences.</li>
+            <li>Turn the tailored audiences toggle off so advertisers can’t add you to custom lists.</li>
+            <li><em>Confirm:</em> Tap Save to opt out of tailored audiences.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-inferred-identity" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, identity, inferred, suggestions, privacy">
+        <h3 class="guide-title">Turn Off Identity-Based Suggestions</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Tailored suggestions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Tailored suggestions.</li>
+            <li>Switch off tailored suggestions so X doesn’t use your identity to recommend content or ads.</li>
+            <li><em>Confirm:</em> Click Save to keep suggestions off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Tailored suggestions.</li>
+            <li>Switch off tailored suggestions so X doesn’t use your identity to recommend content or ads.</li>
+            <li><em>Confirm:</em> Tap Save to keep suggestions off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Tailored suggestions.</li>
+            <li>Switch off tailored suggestions so X doesn’t use your identity to recommend content or ads.</li>
+            <li><em>Confirm:</em> Tap Save to keep suggestions off.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="turn-off-location-based-ads" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, location, places, privacy, targeting">
+        <h3 class="guide-title">Turn Off Location-Based Ads</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Location information</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Location information.</li>
+            <li>Turn off location-based ad personalization so nearby places don’t influence what you see.</li>
+            <li><em>Confirm:</em> Click Save to disable location-based ads.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Location information.</li>
+            <li>Turn off location-based ad personalization so nearby places don’t influence what you see.</li>
+            <li><em>Confirm:</em> Tap Save to disable location-based ads.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Location information.</li>
+            <li>Turn off location-based ad personalization so nearby places don’t influence what you see.</li>
+            <li><em>Confirm:</em> Tap Save to disable location-based ads.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-inferred-app-activity" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, apps, activity, privacy, tracking">
+        <h3 class="guide-title">Turn Off Ads Based on App Activity</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Inferred identity from apps on your device</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Inferred identity from apps on your device.</li>
+            <li>Turn this setting off so X stops using installed apps to personalize ads.</li>
+            <li><em>Confirm:</em> Click Save to block app-based personalization.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Inferred identity from apps on your device.</li>
+            <li>Turn this setting off so X stops using installed apps to personalize ads.</li>
+            <li><em>Confirm:</em> Tap Save to block app-based personalization.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Inferred identity from apps on your device.</li>
+            <li>Turn this setting off so X stops using installed apps to personalize ads.</li>
+            <li><em>Confirm:</em> Tap Save to block app-based personalization.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="limit-ads-based-on-places" class="guide-card" data-platform="x" data-category="Ads &amp; Personalization" data-keywords="ads, places, history, privacy, targeting">
+        <h3 class="guide-title">Limit Ads Based on Places You’ve Been</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Ads preferences → Places you’ve been</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Ads preferences → Places you’ve been.</li>
+            <li>Turn off Places you’ve been so ads ignore your location history.</li>
+            <li><em>Confirm:</em> Click Save to keep place-based ads off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Places you’ve been.</li>
+            <li>Turn off Places you’ve been so ads ignore your location history.</li>
+            <li><em>Confirm:</em> Tap Save to keep place-based ads off.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Ads preferences → Places you’ve been.</li>
+            <li>Turn off Places you’ve been so ads ignore your location history.</li>
+            <li><em>Confirm:</em> Tap Save to keep place-based ads off.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="download-x-data-archive" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="archive, download, data, export, privacy">
+        <h3 class="guide-title">Download Your X Data Archive</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Download an archive of your data → Request archive</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Download an archive of your data → Request archive.</li>
+            <li>Click Request archive and confirm your password to start the export.</li>
+            <li><em>Confirm:</em> Click Done and wait for the email with your download link.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Download an archive of your data → Request archive.</li>
+            <li>Tap Request archive and confirm your password to start the export.</li>
+            <li><em>Confirm:</em> Tap Done and wait for the email with your download link.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Download an archive of your data → Request archive.</li>
+            <li>Tap Request archive and confirm your password to start the export.</li>
+            <li><em>Confirm:</em> Tap Done and wait for the email with your download link.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="download-spaces-data" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="spaces, download, archive, audio, data">
+        <h3 class="guide-title">Download Your Spaces Data</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Download an archive of your data → Download Spaces data</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Download an archive of your data → Download Spaces data.</li>
+            <li>Click Request download to export your Spaces recordings and metadata.</li>
+            <li><em>Confirm:</em> Click Done and watch for the email when your Spaces archive is ready.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Download an archive of your data → Download Spaces data.</li>
+            <li>Tap Request download to export your Spaces recordings and metadata.</li>
+            <li><em>Confirm:</em> Tap Done and watch for the email when your Spaces archive is ready.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Download an archive of your data → Download Spaces data.</li>
+            <li>Tap Request download to export your Spaces recordings and metadata.</li>
+            <li><em>Confirm:</em> Tap Done and watch for the email when your Spaces archive is ready.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="access-ads-profile" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="ads data, profile, download, privacy, report">
+        <h3 class="guide-title">Access Your Ads Data Profile</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Your Twitter data → Ads data</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Your Twitter data → Ads data.</li>
+            <li>Select Ads data and click Request data to view how advertisers profile you.</li>
+            <li><em>Confirm:</em> Click Done and check your inbox for the ads data export.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Ads data.</li>
+            <li>Select Ads data and tap Request data to view how advertisers profile you.</li>
+            <li><em>Confirm:</em> Tap Done and check your inbox for the ads data export.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Ads data.</li>
+            <li>Select Ads data and tap Request data to view how advertisers profile you.</li>
+            <li><em>Confirm:</em> Tap Done and check your inbox for the ads data export.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-login-history-report" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="login history, report, data, security, audit">
+        <h3 class="guide-title">Review Login History Report</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Your Twitter data → Account history → Login history</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Your Twitter data → Account history → Login history.</li>
+            <li>Download the login history report and review each recorded sign-in.</li>
+            <li><em>Confirm:</em> Click Done after reviewing the report for suspicious activity.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Login history.</li>
+            <li>Download the login history report and review each recorded sign-in.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the report for suspicious activity.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Login history.</li>
+            <li>Download the login history report and review each recorded sign-in.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the report for suspicious activity.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-account-access-history" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="account access, history, data, report, audit">
+        <h3 class="guide-title">Review Account Access History</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Your Twitter data → Account history → Account access history</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Your Twitter data → Account history → Account access history.</li>
+            <li>Download the access history report and check each entry for apps or sessions you don’t recognize.</li>
+            <li><em>Confirm:</em> Click Done once you’ve reviewed and removed unfamiliar access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Account access history.</li>
+            <li>Download the access history report and check each entry for apps or sessions you don’t recognize.</li>
+            <li><em>Confirm:</em> Tap Done once you’ve reviewed and removed unfamiliar access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Account access history.</li>
+            <li>Download the access history report and check each entry for apps or sessions you don’t recognize.</li>
+            <li><em>Confirm:</em> Tap Done once you’ve reviewed and removed unfamiliar access.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="deactivate-your-account" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="deactivate, account, closure, privacy, data">
+        <h3 class="guide-title">Deactivate Your Account</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Deactivate your account</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Deactivate your account.</li>
+            <li>Review the reminders, scroll to the bottom, and click Deactivate.</li>
+            <li><em>Confirm:</em> Enter your password and click Deactivate account.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Deactivate your account.</li>
+            <li>Review the reminders, scroll to the bottom, and tap Deactivate.</li>
+            <li><em>Confirm:</em> Enter your password and tap Deactivate account.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Deactivate your account.</li>
+            <li>Review the reminders, scroll to the bottom, and tap Deactivate.</li>
+            <li><em>Confirm:</em> Enter your password and tap Deactivate account.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="cancel-account-deactivation" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="reactivate, deactivation, account, login, restore">
+        <h3 class="guide-title">Cancel Account Deactivation</h3>
+        <p class="settings-path"><strong>Path:</strong> Sign in → Reactivate</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com.</li>
+            <li>Enter your username or email and password.</li>
+            <li>Read the reactivation notice shown after deactivation.</li>
+            <li>Click Reactivate to restore your account.</li>
+            <li><em>Confirm:</em> Click Yes when asked to keep your account active.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Sign in with your username or email and password.</li>
+            <li>Read the reactivation notice shown after deactivation.</li>
+            <li>Tap Reactivate to restore your account.</li>
+            <li><em>Confirm:</em> Tap Yes when asked to keep your account active.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Sign in with your username or email and password.</li>
+            <li>Read the reactivation notice shown after deactivation.</li>
+            <li>Tap Reactivate to restore your account.</li>
+            <li><em>Confirm:</em> Tap Yes when asked to keep your account active.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="update-account-country" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="country, account info, data, settings, region">
+        <h3 class="guide-title">Update Your Account Country</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Your account → Account information → Country</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Your account → Account information → Country.</li>
+            <li>Choose the correct country for your account so legal notices and ads match your location.</li>
+            <li><em>Confirm:</em> Click Save to update the country setting.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Country.</li>
+            <li>Choose the correct country for your account so legal notices and ads match your location.</li>
+            <li><em>Confirm:</em> Tap Save to update the country setting.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Your account → Account information → Country.</li>
+            <li>Choose the correct country for your account so legal notices and ads match your location.</li>
+            <li><em>Confirm:</em> Tap Save to update the country setting.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="download-device-history" class="guide-card" data-platform="x" data-category="Data &amp; Archive" data-keywords="device history, download, security, data, report">
+        <h3 class="guide-title">Download Your Device Login History</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Your Twitter data → Account history → Devices</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Your Twitter data → Account history → Devices.</li>
+            <li>Request the devices report to see every phone or browser that accessed your account.</li>
+            <li><em>Confirm:</em> Click Done after reviewing the devices report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Devices.</li>
+            <li>Request the devices report to see every phone or browser that accessed your account.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the devices report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Your Twitter data → Account history → Devices.</li>
+            <li>Request the devices report to see every phone or browser that accessed your account.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the devices report.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-spaces-listening" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, listening, privacy, activity, audio">
+        <h3 class="guide-title">Hide Your Spaces Listening Activity</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Allow followers to see which Spaces you&#x27;re listening to</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Allow followers to see which Spaces you're listening to.</li>
+            <li>Turn this toggle off so followers can’t see the Spaces you join.</li>
+            <li><em>Confirm:</em> Click Save to keep listening activity private.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow followers to see which Spaces you're listening to.</li>
+            <li>Turn this toggle off so followers can’t see the Spaces you join.</li>
+            <li><em>Confirm:</em> Tap Save to keep listening activity private.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow followers to see which Spaces you're listening to.</li>
+            <li>Turn this toggle off so followers can’t see the Spaces you join.</li>
+            <li><em>Confirm:</em> Tap Save to keep listening activity private.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="hide-spaces-hosting" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, hosting, privacy, activity, audio">
+        <h3 class="guide-title">Hide Spaces You Host from Followers</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Allow followers to see which Spaces you&#x27;re hosting</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Allow followers to see which Spaces you're hosting.</li>
+            <li>Turn this toggle off so others can’t see when you host a Space unless you invite them.</li>
+            <li><em>Confirm:</em> Click Save to hide your hosting activity.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow followers to see which Spaces you're hosting.</li>
+            <li>Turn this toggle off so others can’t see when you host a Space unless you invite them.</li>
+            <li><em>Confirm:</em> Tap Save to hide your hosting activity.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow followers to see which Spaces you're hosting.</li>
+            <li>Turn this toggle off so others can’t see when you host a Space unless you invite them.</li>
+            <li><em>Confirm:</em> Tap Save to hide your hosting activity.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="limit-space-invite-speakers" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, invite, speaker, privacy, control">
+        <h3 class="guide-title">Limit Who Can Invite You to Speak</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Allow people to invite you to speak</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Allow people to invite you to speak.</li>
+            <li>Set invites to People you follow so random listeners can’t request you as a speaker.</li>
+            <li><em>Confirm:</em> Click Save to lock your invite preference.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow people to invite you to speak.</li>
+            <li>Set invites to People you follow so random listeners can’t request you as a speaker.</li>
+            <li><em>Confirm:</em> Tap Save to lock your invite preference.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow people to invite you to speak.</li>
+            <li>Set invites to People you follow so random listeners can’t request you as a speaker.</li>
+            <li><em>Confirm:</em> Tap Save to lock your invite preference.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disable-space-speaker-requests" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, requests, speaker, control, audio">
+        <h3 class="guide-title">Turn Off Space Speaker Requests</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Allow audience to request to speak</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Allow audience to request to speak.</li>
+            <li>Turn this setting off so audience members can’t request speaking slots automatically.</li>
+            <li><em>Confirm:</em> Click Save to disable speaker requests.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow audience to request to speak.</li>
+            <li>Turn this setting off so audience members can’t request speaking slots automatically.</li>
+            <li><em>Confirm:</em> Tap Save to disable speaker requests.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow audience to request to speak.</li>
+            <li>Turn this setting off so audience members can’t request speaking slots automatically.</li>
+            <li><em>Confirm:</em> Tap Save to disable speaker requests.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-spaces-captions" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, captions, accessibility, audio, transcript">
+        <h3 class="guide-title">Enable Automatic Captions in Spaces</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Allow automatic captions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Allow automatic captions.</li>
+            <li>Turn automatic captions on so listeners see live transcriptions.</li>
+            <li><em>Confirm:</em> Click Save to keep captions enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow automatic captions.</li>
+            <li>Turn automatic captions on so listeners see live transcriptions.</li>
+            <li><em>Confirm:</em> Tap Save to keep captions enabled.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Allow automatic captions.</li>
+            <li>Turn automatic captions on so listeners see live transcriptions.</li>
+            <li><em>Confirm:</em> Tap Save to keep captions enabled.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="set-spaces-caption-language" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, caption language, audio, accessibility, settings">
+        <h3 class="guide-title">Set Your Spaces Caption Language</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Spaces → Caption language</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Spaces → Caption language.</li>
+            <li>Choose the language you want captions to use during your Spaces.</li>
+            <li><em>Confirm:</em> Click Save to store the caption language.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Caption language.</li>
+            <li>Choose the language you want captions to use during your Spaces.</li>
+            <li><em>Confirm:</em> Tap Save to store the caption language.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Spaces → Caption language.</li>
+            <li>Choose the language you want captions to use during your Spaces.</li>
+            <li><em>Confirm:</em> Tap Save to store the caption language.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="download-space-recording" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, recording, download, audio, host">
+        <h3 class="guide-title">Download a Space Recording</h3>
+        <p class="settings-path"><strong>Path:</strong> Host view → Recording → Download</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>From the sidebar, click Monetization or Creator Studio and open Recorded Spaces.</li>
+            <li>Select the Space recording you want to export.</li>
+            <li>Click Download to save the audio file to your device.</li>
+            <li><em>Confirm:</em> Click Download again if the browser prompts for confirmation.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo → Creator Studio → Recorded Spaces.</li>
+            <li>Select the Space recording you want to export.</li>
+            <li>Tap Download to save the audio file to your device.</li>
+            <li><em>Confirm:</em> Tap Download again if asked to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo → Creator Studio → Recorded Spaces.</li>
+            <li>Select the Space recording you want to export.</li>
+            <li>Tap Download to save the audio file to your device.</li>
+            <li><em>Confirm:</em> Tap Download again if asked to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="delete-space-recording" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, recording, delete, audio, host">
+        <h3 class="guide-title">Delete a Space Recording</h3>
+        <p class="settings-path"><strong>Path:</strong> Host view → Recording → Delete</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open Creator Studio → Recorded Spaces.</li>
+            <li>Select the Space recording you want to remove.</li>
+            <li>Click Delete recording and review the warning.</li>
+            <li><em>Confirm:</em> Click Delete to permanently remove the recording.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap profile photo → Creator Studio → Recorded Spaces.</li>
+            <li>Select the Space recording you want to remove.</li>
+            <li>Tap Delete recording and review the warning.</li>
+            <li><em>Confirm:</em> Tap Delete to permanently remove the recording.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap profile photo → Creator Studio → Recorded Spaces.</li>
+            <li>Select the Space recording you want to remove.</li>
+            <li>Tap Delete recording and review the warning.</li>
+            <li><em>Confirm:</em> Tap Delete to permanently remove the recording.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="block-user-in-space" class="guide-card" data-platform="x" data-category="Spaces &amp; Audio" data-keywords="spaces, block, safety, moderation, audio">
+        <h3 class="guide-title">Block a User in Your Space</h3>
+        <p class="settings-path"><strong>Path:</strong> Live Space → Participant menu → Block</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Start or join your live Space on twitter.com.</li>
+            <li>Open the participants list and find the user causing issues.</li>
+            <li>Click their profile thumbnail and choose Block.</li>
+            <li>Confirm that blocking removes them from the Space and future sessions.</li>
+            <li><em>Confirm:</em> Click Block to remove the user immediately.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app and start or join your Space.</li>
+            <li>Open the participants list and find the user causing issues.</li>
+            <li>Tap their profile thumbnail and choose Block.</li>
+            <li>Confirm that blocking removes them from the Space and future sessions.</li>
+            <li><em>Confirm:</em> Tap Block to remove the user immediately.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS and start or join your Space.</li>
+            <li>Open the participants list and find the user causing issues.</li>
+            <li>Tap their profile thumbnail and choose Block.</li>
+            <li>Confirm that blocking removes them from the Space and future sessions.</li>
+            <li><em>Confirm:</em> Tap Block to remove the user immediately.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-muted-accounts" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="muted, accounts, review, silence, manage">
+        <h3 class="guide-title">Review Muted Accounts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted accounts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted accounts.</li>
+            <li>Scan your muted accounts list and unmute anyone you still want to hear from.</li>
+            <li><em>Confirm:</em> Click Unmute to restore an account’s posts.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted accounts.</li>
+            <li>Scan your muted accounts list and unmute anyone you still want to hear from.</li>
+            <li><em>Confirm:</em> Tap Unmute to restore an account’s posts.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted accounts.</li>
+            <li>Scan your muted accounts list and unmute anyone you still want to hear from.</li>
+            <li><em>Confirm:</em> Tap Unmute to restore an account’s posts.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-blocked-accounts" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="blocked, accounts, review, safety, manage">
+        <h3 class="guide-title">Review Blocked Accounts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Blocked accounts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Blocked accounts.</li>
+            <li>Check your blocked accounts list and unblock anyone you no longer need to restrict.</li>
+            <li><em>Confirm:</em> Click Unblock to restore access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Blocked accounts.</li>
+            <li>Check your blocked accounts list and unblock anyone you no longer need to restrict.</li>
+            <li><em>Confirm:</em> Tap Unblock to restore access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Blocked accounts.</li>
+            <li>Check your blocked accounts list and unblock anyone you no longer need to restrict.</li>
+            <li><em>Confirm:</em> Tap Unblock to restore access.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="add-muted-word" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="muted words, filter, language, safety, control">
+        <h3 class="guide-title">Add a Muted Word</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted words</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted words.</li>
+            <li>Click the plus icon, add a word or phrase, choose where to mute it, and click Save.</li>
+            <li><em>Confirm:</em> Click Save to add the muted word.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted words.</li>
+            <li>Tap the plus icon, add a word or phrase, choose where to mute it, and tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to add the muted word.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted words.</li>
+            <li>Tap the plus icon, add a word or phrase, choose where to mute it, and tap Save.</li>
+            <li><em>Confirm:</em> Tap Save to add the muted word.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="remove-muted-word" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="muted words, remove, filter, control, manage">
+        <h3 class="guide-title">Remove a Muted Word</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted words</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted words.</li>
+            <li>Open the muted word, review its scope, and click Delete word.</li>
+            <li><em>Confirm:</em> Click Delete to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted words.</li>
+            <li>Open the muted word, review its scope, and tap Delete word.</li>
+            <li><em>Confirm:</em> Tap Delete to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted words.</li>
+            <li>Open the muted word, review its scope, and tap Delete word.</li>
+            <li><em>Confirm:</em> Tap Delete to confirm.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="enable-quality-filter" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="notifications, quality filter, spam, mute, safety">
+        <h3 class="guide-title">Enable Quality Filter for Notifications</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted notifications → Quality filter</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted notifications → Quality filter.</li>
+            <li>Turn on the Quality filter to hide lower-quality notifications.</li>
+            <li><em>Confirm:</em> Click Save to enable the filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Quality filter.</li>
+            <li>Turn on the Quality filter to hide lower-quality notifications.</li>
+            <li><em>Confirm:</em> Tap Save to enable the filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Quality filter.</li>
+            <li>Turn on the Quality filter to hide lower-quality notifications.</li>
+            <li><em>Confirm:</em> Tap Save to enable the filter.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="filter-notifications-strangers" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="notifications, filter, strangers, mute, spam">
+        <h3 class="guide-title">Filter Notifications from People You Don’t Follow</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted notifications → Notifications from people you don&#x27;t follow</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted notifications → Notifications from people you don't follow.</li>
+            <li>Turn this filter on to hide pings from accounts you don’t follow.</li>
+            <li><em>Confirm:</em> Click Save to keep the filter on.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Notifications from people you don't follow.</li>
+            <li>Turn this filter on to hide pings from accounts you don’t follow.</li>
+            <li><em>Confirm:</em> Tap Save to keep the filter on.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Notifications from people you don't follow.</li>
+            <li>Turn this filter on to hide pings from accounts you don’t follow.</li>
+            <li><em>Confirm:</em> Tap Save to keep the filter on.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="filter-notifications-unconfirmed" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="notifications, filter, unconfirmed, mute, spam">
+        <h3 class="guide-title">Filter Notifications from Unconfirmed Accounts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Privacy and safety → Mute and block → Muted notifications → Notifications from unconfirmed email</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Privacy and safety → Mute and block → Muted notifications → Notifications from unconfirmed email.</li>
+            <li>Toggle on the filter to hide notifications from accounts without confirmed email addresses.</li>
+            <li><em>Confirm:</em> Click Save to enforce the filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Notifications from unconfirmed email.</li>
+            <li>Toggle on the filter to hide notifications from accounts without confirmed email addresses.</li>
+            <li><em>Confirm:</em> Tap Save to enforce the filter.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Privacy and safety → Mute and block → Muted notifications → Notifications from unconfirmed email.</li>
+            <li>Toggle on the filter to hide notifications from accounts without confirmed email addresses.</li>
+            <li><em>Confirm:</em> Tap Save to enforce the filter.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="report-an-account" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="report, account, abuse, safety, moderation">
+        <h3 class="guide-title">Report an Account for Abuse</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile → ••• → Report</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the profile you want to report.</li>
+            <li>Click the ••• icon and choose Report.</li>
+            <li>Select the reason that best describes the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and click Submit report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the profile you want to report.</li>
+            <li>Tap the ••• icon and choose Report.</li>
+            <li>Select the reason that best describes the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and tap Submit report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the profile you want to report.</li>
+            <li>Tap the ••• icon and choose Report.</li>
+            <li>Select the reason that best describes the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and tap Submit report.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="report-a-tweet" class="guide-card" data-platform="x" data-category="Mute/Block/Reports" data-keywords="report, tweet, abuse, safety, moderation">
+        <h3 class="guide-title">Report a Tweet for Abuse</h3>
+        <p class="settings-path"><strong>Path:</strong> Tweet → ••• → Report Tweet</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Open the tweet that violates the rules.</li>
+            <li>Click the ••• icon and choose Report Tweet.</li>
+            <li>Select the rule that best matches the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and click Submit report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Open the tweet that violates the rules.</li>
+            <li>Tap the ••• icon and choose Report Tweet.</li>
+            <li>Select the rule that best matches the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and tap Submit report.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Open the tweet that violates the rules.</li>
+            <li>Tap the ••• icon and choose Report Tweet.</li>
+            <li>Select the rule that best matches the violation.</li>
+            <li><em>Confirm:</em> Follow the prompts and tap Submit report.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-connected-apps" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="connected apps, oauth, permissions, security, review">
+        <h3 class="guide-title">Review Connected Apps</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Connected apps</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Review each connected app and note what permissions it has.</li>
+            <li><em>Confirm:</em> Click Done after auditing the list.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Review each connected app and note what permissions it has.</li>
+            <li><em>Confirm:</em> Tap Done after auditing the list.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Review each connected app and note what permissions it has.</li>
+            <li><em>Confirm:</em> Tap Done after auditing the list.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="revoke-connected-app" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="connected apps, revoke, permissions, security, oauth">
+        <h3 class="guide-title">Revoke a Connected App</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Connected apps</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Select the app you no longer trust and click Revoke access.</li>
+            <li><em>Confirm:</em> Click Revoke to remove the app’s access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Select the app you no longer trust and tap Revoke access.</li>
+            <li><em>Confirm:</em> Tap Revoke to remove the app’s access.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected apps.</li>
+            <li>Select the app you no longer trust and tap Revoke access.</li>
+            <li><em>Confirm:</em> Tap Revoke to remove the app’s access.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="review-connected-accounts" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="connected accounts, login, apple, google, permissions">
+        <h3 class="guide-title">Review Connected Accounts</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Connected accounts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Check which Apple, Google, or other accounts are linked for login.</li>
+            <li><em>Confirm:</em> Click Done after reviewing linked accounts.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Check which Apple, Google, or other accounts are linked for login.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing linked accounts.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Check which Apple, Google, or other accounts are linked for login.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing linked accounts.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="disconnect-connected-account" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="connected accounts, disconnect, login, security, unlink">
+        <h3 class="guide-title">Disconnect a Linked Account</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Connected accounts</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Select the linked account you no longer want to use and click Disconnect.</li>
+            <li><em>Confirm:</em> Click Disconnect to remove the linked account.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Select the linked account you no longer want to use and tap Disconnect.</li>
+            <li><em>Confirm:</em> Tap Disconnect to remove the linked account.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Connected accounts.</li>
+            <li>Select the linked account you no longer want to use and tap Disconnect.</li>
+            <li><em>Confirm:</em> Tap Disconnect to remove the linked account.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="inspect-app-session-details" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="sessions, details, oauth, apps, security">
+        <h3 class="guide-title">Inspect App Session Details</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Sessions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Sessions.</li>
+            <li>Open each session to see the device, app name, and authorization time.</li>
+            <li><em>Confirm:</em> Click Done after reviewing the session info.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Open each session to see the device, app name, and authorization time.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the session info.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Open each session to see the device, app name, and authorization time.</li>
+            <li><em>Confirm:</em> Tap Done after reviewing the session info.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="revoke-app-session" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="sessions, revoke, oauth, apps, security">
+        <h3 class="guide-title">Revoke an App Session</h3>
+        <p class="settings-path"><strong>Path:</strong> Profile photo → Settings and privacy → Security and account access → Apps and sessions → Sessions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>Go to twitter.com and sign in.</li>
+            <li>Click More (left sidebar) → Settings and privacy.</li>
+            <li>Click Security and account access → Apps and sessions → Sessions.</li>
+            <li>Click Log out next to any session or app you don’t recognize.</li>
+            <li><em>Confirm:</em> Click Log out to revoke the session.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open the X app.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Tap Log out next to any session or app you don’t recognize.</li>
+            <li><em>Confirm:</em> Tap Log out to revoke the session.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open the X app on iOS.</li>
+            <li>Tap your profile photo (top left) → Settings and privacy.</li>
+            <li>Tap Security and account access → Apps and sessions → Sessions.</li>
+            <li>Tap Log out next to any session or app you don’t recognize.</li>
+            <li><em>Confirm:</em> Tap Log out to revoke the session.</li>
+          </ol>
+        </details>
+      </article>
+      <article id="reset-mobile-app-permissions" class="guide-card" data-platform="x" data-category="App Permissions" data-keywords="mobile, permissions, camera, microphone, privacy">
+        <h3 class="guide-title">Reset X App Permissions on Your Phone</h3>
+        <p class="settings-path"><strong>Path:</strong> Device settings → Apps → X → Permissions</p>
+        <details open>
+          <summary>Web (browser)</summary>
+          <ol>
+            <li>This action must be completed on your phone.</li>
+            <li>Open your device settings and search for the X app.</li>
+            <li>Open Permissions to review camera, microphone, contacts, and storage access.</li>
+            <li>Disable any permission the app doesn’t need.</li>
+            <li><em>Confirm:</em> Save or back out to apply the new permission state.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>Android app</summary>
+          <ol>
+            <li>Open Android Settings → Apps → X.</li>
+            <li>Tap Permissions to review camera, microphone, contacts, and storage access.</li>
+            <li>Turn off any permission the app doesn’t need.</li>
+            <li>Back out to make sure the change sticks.</li>
+            <li><em>Confirm:</em> Tap Don’t allow when asked to confirm.</li>
+          </ol>
+        </details>
+        <details>
+          <summary>iOS app</summary>
+          <ol>
+            <li>Open iOS Settings → X.</li>
+            <li>Review toggles for Camera, Microphone, Contacts, Bluetooth, and Photos.</li>
+            <li>Turn off any permission you no longer want the app to use.</li>
+            <li>Return to save the new state.</li>
+            <li><em>Confirm:</em> Tap Don’t Allow if iOS prompts for confirmation.</li>
+          </ol>
+        </details>
+      </article>
+
+    </section>
+
+    <p class="coming-soon" id="more-platforms-note" data-i18n="platforms.moreComing">
+      More platforms are coming soon.
+    </p>
+
+    <button class="back-to-top" aria-label="Back to top">↑</button>
+  </main>
+
+  <script src="../assets/js/self-audit.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the X platform page with the new standardized layout, filter buttons, and guide grid
- add 100 detailed guide cards covering account security, privacy, messaging, media, discovery, ads, data, spaces, moderation, and app permissions actions on X
- surface the cross-platform "More platforms are coming soon." note on the platform index page

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4d9508f84832385937b7f26d83e49